### PR TITLE
Add Claude Code JSON context parsing (Story 1.2) closes #10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "nu-ansi-term",
+ "predicates",
  "rstest",
  "serde",
  "serde_json",
@@ -226,6 +233,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -381,12 +397,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -421,7 +452,10 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ nu-ansi-term       = "0.50"
 [dev-dependencies]
 rstest     = "0.26"
 assert_cmd = "2"
+predicates = "3"
 
 [profile.release]
 opt-level     = 3

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,201 @@
+use serde::Deserialize;
+use std::io::Read;
+
+/// Typed representation of the complete Claude Code session JSON payload.
+/// All fields are `Option<T>` because Claude Code may omit any field depending on
+/// session state, mode flags, and version. `deny_unknown_fields` is intentionally
+/// NOT used — future Claude Code versions may add fields.
+#[derive(Debug, Deserialize, Default)]
+pub struct Context {
+    pub cwd: Option<String>,
+    pub session_id: Option<String>,
+    pub transcript_path: Option<String>,
+    pub version: Option<String>,
+    /// Top-level boolean (NOT inside context_window).
+    pub exceeds_200k_tokens: Option<bool>,
+    pub model: Option<Model>,
+    pub workspace: Option<Workspace>,
+    pub output_style: Option<OutputStyle>,
+    pub cost: Option<Cost>,
+    /// May be entirely absent in some Claude Code versions (confirmed absent in v2.0.31).
+    pub context_window: Option<ContextWindow>,
+    /// Absent unless vim mode is enabled.
+    pub vim: Option<Vim>,
+    /// Absent unless --agent flag or agent settings are active.
+    pub agent: Option<Agent>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Model {
+    pub id: Option<String>,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Workspace {
+    pub current_dir: Option<String>,
+    pub project_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct OutputStyle {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Cost {
+    pub total_cost_usd: Option<f64>,
+    pub total_duration_ms: Option<u64>,
+    pub total_api_duration_ms: Option<u64>,
+    pub total_lines_added: Option<i64>,
+    pub total_lines_removed: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ContextWindow {
+    pub total_input_tokens: Option<u64>,
+    pub total_output_tokens: Option<u64>,
+    pub context_window_size: Option<u64>,
+    /// May be null early in a session (before first API response).
+    pub used_percentage: Option<f64>,
+    /// May be null early in a session (before first API response).
+    pub remaining_percentage: Option<f64>,
+    /// Null before the first API call in a session.
+    pub current_usage: Option<CurrentUsage>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct CurrentUsage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Vim {
+    /// "NORMAL" or "INSERT"
+    pub mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Agent {
+    pub name: Option<String>,
+}
+
+/// Deserialize Claude Code session JSON from any reader.
+/// Uses exactly one `serde_json::from_str` call — no per-field parsing.
+///
+/// Returns an error if input is empty or JSON is malformed.
+pub fn from_reader(mut reader: impl Read) -> anyhow::Result<Context> {
+    let mut input = String::new();
+    reader.read_to_string(&mut input)?;
+    if input.trim().is_empty() {
+        anyhow::bail!("empty stdin: no Claude Code session JSON received");
+    }
+    let ctx = serde_json::from_str(&input)?;
+    Ok(ctx)
+}
+
+/// Read stdin to end, then deserialize as Claude Code session JSON.
+/// This is the ONLY place in the entire codebase that reads from stdin.
+///
+/// Returns an error if stdin is empty or JSON is malformed.
+pub fn from_stdin() -> anyhow::Result<Context> {
+    from_reader(std::io::stdin())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FULL_JSON: &str = include_str!("../tests/fixtures/sample_input_full.json");
+    const MINIMAL_JSON: &str = include_str!("../tests/fixtures/sample_input_minimal.json");
+
+    #[test]
+    fn test_deserialize_full_payload() {
+        let ctx: Context = serde_json::from_str(FULL_JSON).unwrap();
+        // Top-level fields
+        assert_eq!(ctx.cwd.as_deref(), Some("/home/user/projects/myapp"));
+        assert_eq!(ctx.session_id.as_deref(), Some("test-session-id"));
+        assert_eq!(
+            ctx.transcript_path.as_deref(),
+            Some("/home/user/.claude/projects/myapp/transcript.jsonl")
+        );
+        assert_eq!(ctx.version.as_deref(), Some("1.0.80"));
+        assert_eq!(ctx.exceeds_200k_tokens, Some(false));
+        // Model
+        let model = ctx.model.as_ref().unwrap();
+        assert_eq!(model.id.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(model.display_name.as_deref(), Some("Opus"));
+        // Workspace
+        let ws = ctx.workspace.as_ref().unwrap();
+        assert_eq!(ws.current_dir.as_deref(), Some("/home/user/projects/myapp"));
+        assert_eq!(ws.project_dir.as_deref(), Some("/home/user/projects/myapp"));
+        // OutputStyle
+        assert_eq!(
+            ctx.output_style.as_ref().unwrap().name.as_deref(),
+            Some("default")
+        );
+        // Cost — all sub-fields
+        let cost = ctx.cost.as_ref().unwrap();
+        assert_eq!(cost.total_cost_usd, Some(0.01234));
+        assert_eq!(cost.total_duration_ms, Some(45000));
+        assert_eq!(cost.total_api_duration_ms, Some(2300));
+        assert_eq!(cost.total_lines_added, Some(156));
+        assert_eq!(cost.total_lines_removed, Some(23));
+        // ContextWindow — all sub-fields
+        let cw = ctx.context_window.as_ref().unwrap();
+        assert_eq!(cw.total_input_tokens, Some(15234));
+        assert_eq!(cw.total_output_tokens, Some(4521));
+        assert_eq!(cw.context_window_size, Some(200000));
+        assert_eq!(cw.used_percentage, Some(8.0));
+        assert_eq!(cw.remaining_percentage, Some(92.0));
+        let cu = cw.current_usage.as_ref().unwrap();
+        assert_eq!(cu.input_tokens, Some(8500));
+        assert_eq!(cu.output_tokens, Some(1200));
+        assert_eq!(cu.cache_creation_input_tokens, Some(5000));
+        assert_eq!(cu.cache_read_input_tokens, Some(2000));
+        // Vim
+        assert_eq!(ctx.vim.as_ref().unwrap().mode.as_deref(), Some("NORMAL"));
+        // Agent
+        assert_eq!(
+            ctx.agent.as_ref().unwrap().name.as_deref(),
+            Some("security-reviewer")
+        );
+    }
+
+    #[test]
+    fn test_deserialize_minimal_payload() {
+        let ctx: Context = serde_json::from_str(MINIMAL_JSON).unwrap();
+        assert!(ctx.vim.is_none());
+        assert!(ctx.agent.is_none());
+        assert!(ctx.context_window.is_none());
+        assert_eq!(ctx.cost.as_ref().unwrap().total_cost_usd, Some(0.53));
+    }
+
+    #[test]
+    fn test_unknown_fields_ignored() {
+        let json = r#"{"session_id":"abc","cwd":"/","transcript_path":"/t","version":"99.0","exceeds_200k_tokens":false,"unknown_future_field":true,"nested_unknown":{"key":"value"},"model":{"id":"test","display_name":"Test"},"workspace":{"current_dir":"/","project_dir":"/"},"output_style":{"name":"default"},"cost":{"total_cost_usd":0.0}}"#;
+        let ctx: Context = serde_json::from_str(json).unwrap();
+        assert_eq!(ctx.session_id.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn test_malformed_json_returns_error() {
+        let result: Result<Context, _> = serde_json::from_str("not valid json {{{");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_reader_returns_error() {
+        let result = from_reader("".as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_whitespace_only_reader_returns_error() {
+        let result = from_reader("   \n\t  ".as_bytes());
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod context;
+
 // Re-exports added as modules are implemented in future stories.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,1 +1,20 @@
-fn main() {}
+fn main() {
+    // Initialize tracing subscriber — stderr ONLY.
+    // Must be called before any tracing:: macro. Respects RUST_LOG env var.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    match cship::context::from_stdin() {
+        Ok(_ctx) => {
+            // Context successfully parsed.
+            // Rendering pipeline added in Story 1.3 (config loading) and Story 1.4 (renderer).
+            // No stdout output in this story — main.rs is the sole stdout owner (Story 1.4).
+        }
+        Err(e) => {
+            tracing::error!("cship: failed to parse Claude Code session JSON: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,56 @@
+use assert_cmd::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn test_valid_full_json_exits_zero_with_no_stdout() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cargo_bin_cmd!("cship")
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_valid_minimal_json_exits_zero() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_minimal.json").unwrap();
+    cargo_bin_cmd!("cship")
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_empty_stdin_exits_nonzero_with_no_stdout() {
+    cargo_bin_cmd!("cship")
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "failed to parse Claude Code session JSON",
+        ));
+}
+
+#[test]
+fn test_malformed_json_exits_nonzero_with_no_stdout() {
+    cargo_bin_cmd!("cship")
+        .write_stdin("not valid json{{{")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "failed to parse Claude Code session JSON",
+        ));
+}
+
+#[test]
+fn test_unknown_fields_silently_ignored() {
+    let json = r#"{"session_id":"abc","cwd":"/tmp","transcript_path":"/tmp/t.jsonl","version":"1.0","exceeds_200k_tokens":false,"model":{"id":"claude-test","display_name":"Test"},"workspace":{"current_dir":"/tmp","project_dir":"/tmp"},"output_style":{"name":"default"},"cost":{"total_cost_usd":0.0},"unknown_future_field":true,"nested_unknown":{"key":"value"}}"#;
+    cargo_bin_cmd!("cship")
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}

--- a/tests/fixtures/sample_input_full.json
+++ b/tests/fixtures/sample_input_full.json
@@ -1,0 +1,44 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "test-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "1.0.80",
+  "exceeds_200k_tokens": false,
+  "model": {
+    "id": "claude-opus-4-6",
+    "display_name": "Opus"
+  },
+  "workspace": {
+    "current_dir": "/home/user/projects/myapp",
+    "project_dir": "/home/user/projects/myapp"
+  },
+  "output_style": {
+    "name": "default"
+  },
+  "cost": {
+    "total_cost_usd": 0.01234,
+    "total_duration_ms": 45000,
+    "total_api_duration_ms": 2300,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "total_input_tokens": 15234,
+    "total_output_tokens": 4521,
+    "context_window_size": 200000,
+    "used_percentage": 8.0,
+    "remaining_percentage": 92.0,
+    "current_usage": {
+      "input_tokens": 8500,
+      "output_tokens": 1200,
+      "cache_creation_input_tokens": 5000,
+      "cache_read_input_tokens": 2000
+    }
+  },
+  "vim": {
+    "mode": "NORMAL"
+  },
+  "agent": {
+    "name": "security-reviewer"
+  }
+}

--- a/tests/fixtures/sample_input_minimal.json
+++ b/tests/fixtures/sample_input_minimal.json
@@ -1,0 +1,22 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "minimal-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "2.0.31",
+  "exceeds_200k_tokens": false,
+  "model": {
+    "id": "claude-sonnet-4-6",
+    "display_name": "Sonnet"
+  },
+  "workspace": {
+    "current_dir": "/home/user/projects/myapp",
+    "project_dir": "/home/user/projects/myapp"
+  },
+  "output_style": {
+    "name": "default"
+  },
+  "cost": {
+    "total_cost_usd": 0.53,
+    "total_duration_ms": 343171
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `src/context.rs` module to parse Claude Code session JSON from stdin
- Wires up the context module in `src/lib.rs` and `src/main.rs` with tracing-based error handling
- Adds integration tests in `tests/cli.rs` with full and minimal JSON fixture files
- Adds `predicates` dev-dependency for richer test assertions

## Test plan

- [ ] `cargo test` passes all unit and integration tests
- [ ] `cargo build --release` succeeds
- [ ] Binary reads valid Claude Code session JSON from stdin without error
- [ ] Binary exits with code 1 and logs an error on invalid JSON input

🤖 Generated with [Claude Code](https://claude.com/claude-code)