### PR TITLE
Add cost module with threshold styling (Story 2.1)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -44,6 +44,34 @@ pub fn apply_style(content: &str, style_str: Option<&str>) -> String {
     style.paint(content).to_string()
 }
 
+/// Apply style with optional numeric threshold switching.
+/// If `value` >= `critical_threshold` (both Some), applies `critical_style`.
+/// If `value` >= `warn_threshold` (both Some), applies `warn_style`.
+/// Otherwise applies base `style`. Falls back gracefully if thresholds are None.
+///
+/// [Source: architecture.md#Epic 1 Retrospective Addenda — ansi.rs Threshold Extension]
+pub fn apply_style_with_threshold(
+    content: &str,
+    value: Option<f64>,
+    style: Option<&str>,
+    warn_threshold: Option<f64>,
+    warn_style: Option<&str>,
+    critical_threshold: Option<f64>,
+    critical_style: Option<&str>,
+) -> String {
+    if let (Some(val), Some(thresh), Some(crit_style)) = (value, critical_threshold, critical_style)
+        && val >= thresh
+    {
+        return apply_style(content, Some(crit_style));
+    }
+    if let (Some(val), Some(thresh), Some(w_style)) = (value, warn_threshold, warn_style)
+        && val >= thresh
+    {
+        return apply_style(content, Some(w_style));
+    }
+    apply_style(content, style)
+}
+
 fn parse_color(name: &str) -> Option<Color> {
     match name {
         "black" => Some(Color::Black),
@@ -101,5 +129,61 @@ mod tests {
     fn test_bg_prefix_applies_background_color() {
         let result = apply_style("text", Some("bg:blue"));
         assert!(result.contains('\x1b'), "expected ANSI in: {result:?}");
+    }
+
+    #[test]
+    fn test_threshold_below_warn_uses_base_style() {
+        // value 3.0 below warn 5.0 → base style (no ANSI when style is None)
+        let result = apply_style_with_threshold(
+            "$3.00",
+            Some(3.0),
+            None,
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, "$3.00");
+    }
+
+    #[test]
+    fn test_threshold_above_warn_uses_warn_style() {
+        let result = apply_style_with_threshold(
+            "$6.00",
+            Some(6.0),
+            None,
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for warn: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_threshold_above_critical_uses_critical_style() {
+        let result = apply_style_with_threshold(
+            "$12.00",
+            Some(12.0),
+            None,
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("bold red"),
+        );
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for critical: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_threshold_no_thresholds_uses_base() {
+        let result =
+            apply_style_with_threshold("text", Some(100.0), Some("green"), None, None, None, None);
+        assert!(result.contains('\x1b'), "expected base style ANSI");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,13 @@ pub struct CshipConfig {
     pub lines: Option<Vec<String>>,
     /// Configuration for the `[cship.model]` section.
     pub model: Option<ModelConfig>,
+    pub cost: Option<CostConfig>,
+    pub context_bar: Option<ContextBarConfig>,
+    pub context_window: Option<ContextWindowConfig>,
+    pub vim: Option<VimConfig>,
+    pub agent: Option<AgentConfig>,
+    pub session: Option<SessionConfig>,
+    pub workspace: Option<WorkspaceConfig>,
 }
 
 /// Per-module config fields shared by all native CShip modules.
@@ -21,6 +28,104 @@ pub struct ModelConfig {
     pub label: Option<bool>,
     pub warn_threshold: Option<f64>,
     pub critical_threshold: Option<f64>,
+}
+
+/// Configuration for `[cship.cost]` — convenience alias for total cost display.
+#[derive(Debug, Deserialize, Default)]
+pub struct CostConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    /// Reserved — not yet rendered; included for config schema consistency with other modules.
+    pub label: Option<String>,
+    pub warn_threshold: Option<f64>,
+    pub warn_style: Option<String>,
+    pub critical_threshold: Option<f64>,
+    pub critical_style: Option<String>,
+    // Sub-field per-display configs (map to [cship.cost.total_cost_usd] etc.)
+    pub total_cost_usd: Option<CostSubfieldConfig>,
+    pub total_duration_ms: Option<CostSubfieldConfig>,
+    pub total_api_duration_ms: Option<CostSubfieldConfig>,
+    pub total_lines_added: Option<CostSubfieldConfig>,
+    pub total_lines_removed: Option<CostSubfieldConfig>,
+}
+
+/// Configuration for individual `[cship.cost.*]` sub-field modules.
+#[derive(Debug, Deserialize, Default)]
+pub struct CostSubfieldConfig {
+    pub style: Option<String>,
+    /// Reserved — not yet rendered; included for config schema consistency.
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    /// Reserved — not yet rendered; included for config schema consistency.
+    pub label: Option<String>,
+}
+
+/// Configuration for `[cship.context_bar]` — visual progress bar with thresholds.
+/// Implemented in Story 2.2. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct ContextBarConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+    pub warn_threshold: Option<f64>,
+    pub warn_style: Option<String>,
+    pub critical_threshold: Option<f64>,
+    pub critical_style: Option<String>,
+    pub width: Option<u32>,
+}
+
+/// Configuration for `[cship.context_window]` sub-field modules.
+/// Implemented in Story 2.2. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct ContextWindowConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+}
+
+/// Configuration for `[cship.vim]` — vim mode display.
+/// Implemented in Story 2.3. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct VimConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+    pub normal_style: Option<String>,
+    pub insert_style: Option<String>,
+}
+
+/// Configuration for `[cship.agent]` — agent name display.
+/// Implemented in Story 2.3. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct AgentConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+}
+
+/// Configuration for session identity modules (cwd, session_id, transcript_path, etc.).
+/// Implemented in Story 2.4. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct SessionConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+}
+
+/// Configuration for workspace modules (workspace.current_dir, workspace.project_dir).
+/// Implemented in Story 2.4. Defined here so all Epic 2 config is available.
+#[derive(Debug, Deserialize, Default)]
+pub struct WorkspaceConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
 }
 
 /// Private wrapper so `toml::from_str` can extract `[cship]` sections

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -1,0 +1,312 @@
+/// Render the `[cship.cost]` family of modules.
+///
+/// `$cship.cost` — convenience alias: formats total_cost_usd as "$X.XX" with threshold styling.
+/// `$cship.cost.total_cost_usd` — raw USD value, 4 decimal places.
+/// `$cship.cost.total_duration_ms` / `total_api_duration_ms` — integer milliseconds.
+/// `$cship.cost.total_lines_added` / `total_lines_removed` — integer counts.
+///
+/// [Source: epics.md#Story 2.1, architecture.md#Structure Patterns]
+use crate::config::{CostConfig, CostSubfieldConfig, CshipConfig};
+use crate::context::Context;
+
+/// Renders `$cship.cost` — total cost as `$X.XX` with threshold color escalation.
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+
+    // Respect disabled flag — return None silently
+    if cost_cfg.and_then(|c| c.disabled).unwrap_or(false) {
+        return None;
+    }
+
+    // total_cost_usd absent → warn and return None (AC9 requires tracing::warn!)
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_cost_usd) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost: total_cost_usd absent from context");
+            return None;
+        }
+    };
+
+    let symbol = cost_cfg.and_then(|c| c.symbol.as_deref()).unwrap_or("");
+    let content = format!("{symbol}${:.2}", val);
+
+    let style = cost_cfg.and_then(|c| c.style.as_deref());
+    let warn_threshold = cost_cfg.and_then(|c| c.warn_threshold);
+    let warn_style = cost_cfg.and_then(|c| c.warn_style.as_deref());
+    let critical_threshold = cost_cfg.and_then(|c| c.critical_threshold);
+    let critical_style = cost_cfg.and_then(|c| c.critical_style.as_deref());
+
+    Some(crate::ansi::apply_style_with_threshold(
+        &content,
+        Some(val),
+        style,
+        warn_threshold,
+        warn_style,
+        critical_threshold,
+        critical_style,
+    ))
+}
+
+/// Renders `$cship.cost.total_cost_usd` — raw USD value to 4 decimal places.
+pub fn render_total_cost_usd(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+    let sub_cfg = cost_cfg.and_then(|c| c.total_cost_usd.as_ref());
+    if is_subfield_disabled(sub_cfg, cost_cfg) {
+        return None;
+    }
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_cost_usd) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost.total_cost_usd: value absent from context");
+            return None;
+        }
+    };
+    let content = format!("{:.4}", val);
+    Some(apply_subfield_style(&content, sub_cfg))
+}
+
+/// Renders `$cship.cost.total_duration_ms` — total wall time in milliseconds.
+pub fn render_total_duration_ms(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+    let sub_cfg = cost_cfg.and_then(|c| c.total_duration_ms.as_ref());
+    if is_subfield_disabled(sub_cfg, cost_cfg) {
+        return None;
+    }
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_duration_ms) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost.total_duration_ms: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_subfield_style(&val.to_string(), sub_cfg))
+}
+
+/// Renders `$cship.cost.total_api_duration_ms` — API-only duration in milliseconds.
+pub fn render_total_api_duration_ms(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+    let sub_cfg = cost_cfg.and_then(|c| c.total_api_duration_ms.as_ref());
+    if is_subfield_disabled(sub_cfg, cost_cfg) {
+        return None;
+    }
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_api_duration_ms) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost.total_api_duration_ms: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_subfield_style(&val.to_string(), sub_cfg))
+}
+
+/// Renders `$cship.cost.total_lines_added` — cumulative lines added this session.
+pub fn render_total_lines_added(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+    let sub_cfg = cost_cfg.and_then(|c| c.total_lines_added.as_ref());
+    if is_subfield_disabled(sub_cfg, cost_cfg) {
+        return None;
+    }
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_lines_added) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost.total_lines_added: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_subfield_style(&val.to_string(), sub_cfg))
+}
+
+/// Renders `$cship.cost.total_lines_removed` — cumulative lines removed this session.
+pub fn render_total_lines_removed(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let cost_cfg = cfg.cost.as_ref();
+    let sub_cfg = cost_cfg.and_then(|c| c.total_lines_removed.as_ref());
+    if is_subfield_disabled(sub_cfg, cost_cfg) {
+        return None;
+    }
+    let val = match ctx.cost.as_ref().and_then(|c| c.total_lines_removed) {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.cost.total_lines_removed: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_subfield_style(&val.to_string(), sub_cfg))
+}
+
+fn is_subfield_disabled(
+    sub_cfg: Option<&CostSubfieldConfig>,
+    cost_cfg: Option<&CostConfig>,
+) -> bool {
+    // Sub-field explicit disabled takes precedence
+    if let Some(d) = sub_cfg.and_then(|c| c.disabled) {
+        return d;
+    }
+    // Fall through to parent disabled
+    cost_cfg.and_then(|c| c.disabled).unwrap_or(false)
+}
+
+fn apply_subfield_style(content: &str, cfg: Option<&CostSubfieldConfig>) -> String {
+    crate::ansi::apply_style(content, cfg.and_then(|c| c.style.as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CostConfig, CshipConfig};
+    use crate::context::{Context, Cost};
+
+    fn ctx_with_cost(usd: f64) -> Context {
+        Context {
+            cost: Some(Cost {
+                total_cost_usd: Some(usd),
+                total_duration_ms: Some(45000),
+                total_api_duration_ms: Some(2300),
+                total_lines_added: Some(156),
+                total_lines_removed: Some(23),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_cost_renders_dollar_formatted() {
+        let ctx = ctx_with_cost(0.01234);
+        let result = render(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("$0.01".to_string()));
+    }
+
+    #[test]
+    fn test_cost_disabled_returns_none() {
+        let ctx = ctx_with_cost(5.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_cost_absent_returns_none_and_warns() {
+        let ctx = Context::default(); // no cost field
+        let result = render(&ctx, &CshipConfig::default());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_cost_below_warn_uses_base_style() {
+        let ctx = ctx_with_cost(3.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        // No ANSI codes when base style is None and value is below warn
+        assert!(
+            !result.contains('\x1b'),
+            "should not have ANSI when below warn: {result:?}"
+        );
+        assert!(result.contains("$3.00"));
+    }
+
+    #[test]
+    fn test_cost_above_warn_applies_warn_style() {
+        let ctx = ctx_with_cost(6.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected warn ANSI codes: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cost_above_critical_applies_critical_style() {
+        let ctx = ctx_with_cost(12.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected critical ANSI codes: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_subfield_inherits_parent_disabled() {
+        let ctx = ctx_with_cost(5.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        // Sub-fields should inherit parent disabled when not explicitly overridden
+        assert_eq!(render_total_cost_usd(&ctx, &cfg), None);
+        assert_eq!(render_total_duration_ms(&ctx, &cfg), None);
+        assert_eq!(render_total_api_duration_ms(&ctx, &cfg), None);
+        assert_eq!(render_total_lines_added(&ctx, &cfg), None);
+        assert_eq!(render_total_lines_removed(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_render_total_cost_usd_four_decimal_places() {
+        let ctx = ctx_with_cost(0.01234);
+        let result = render_total_cost_usd(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("0.0123".to_string()));
+    }
+
+    #[test]
+    fn test_render_total_duration_ms() {
+        let ctx = ctx_with_cost(0.01);
+        let result = render_total_duration_ms(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("45000".to_string()));
+    }
+
+    #[test]
+    fn test_render_total_api_duration_ms() {
+        let ctx = ctx_with_cost(0.01);
+        let result = render_total_api_duration_ms(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("2300".to_string()));
+    }
+
+    #[test]
+    fn test_render_total_lines_added() {
+        let ctx = ctx_with_cost(0.01);
+        let result = render_total_lines_added(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("156".to_string()));
+    }
+
+    #[test]
+    fn test_render_total_lines_removed() {
+        let ctx = ctx_with_cost(0.01);
+        let result = render_total_lines_removed(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("23".to_string()));
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,4 @@
+pub mod cost;
 pub mod model;
 
 /// Static dispatch registry — the ONLY file modified when adding a new native module.
@@ -9,6 +10,13 @@ pub fn render_module(
 ) -> Option<String> {
     match name {
         "cship.model" => model::render(ctx, cfg),
+        // Cost module — main alias and sub-fields
+        "cship.cost" => cost::render(ctx, cfg),
+        "cship.cost.total_cost_usd" => cost::render_total_cost_usd(ctx, cfg),
+        "cship.cost.total_duration_ms" => cost::render_total_duration_ms(ctx, cfg),
+        "cship.cost.total_api_duration_ms" => cost::render_total_api_duration_ms(ctx, cfg),
+        "cship.cost.total_lines_added" => cost::render_total_lines_added(ctx, cfg),
+        "cship.cost.total_lines_removed" => cost::render_total_lines_removed(ctx, cfg),
         other => {
             tracing::warn!("cship: unknown native module '{other}' — skipping");
             None

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -69,7 +69,7 @@ fn test_config_flag_with_valid_toml_exits_zero() {
         .assert()
         .success()
         // sample_starship.toml has lines = ["$cship.model $git_branch", "$cship.cost"]
-        // model renders "Opus"; git_branch and cost are None → final output contains "Opus"
+        // model renders "Opus"; git_branch is passthrough (None); cost renders "$0.01"
         .stdout(predicate::str::contains("Opus"));
 }
 
@@ -218,4 +218,75 @@ fn test_no_lines_config_produces_empty_stdout() {
         .assert()
         .success()
         .stdout("");
+}
+
+// ── Story 2.1: Cost module integration tests ──────────────────────────────
+
+#[test]
+fn test_cost_renders_dollar_formatted_value() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: cost.total_cost_usd = 0.01234 → "$0.01"
+    cship()
+        .args(["--config", "tests/fixtures/cost_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("$0.01"));
+}
+
+#[test]
+fn test_cost_warn_threshold_applies_ansi_style() {
+    let json = std::fs::read_to_string("tests/fixtures/cost_warn_value.json").unwrap();
+    // cost_warn_value.json: total_cost_usd = 6.0 > warn_threshold 5.0 → ANSI codes
+    cship()
+        .args(["--config", "tests/fixtures/cost_warn.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["));
+}
+
+#[test]
+fn test_cost_critical_threshold_applies_critical_style() {
+    let json = std::fs::read_to_string("tests/fixtures/cost_high.json").unwrap();
+    // cost_high.json: total_cost_usd = 12.0 > critical_threshold 10.0 → ANSI codes
+    cship()
+        .args(["--config", "tests/fixtures/cost_critical.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["));
+}
+
+#[test]
+fn test_cost_disabled_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/cost_disabled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_cost_subfields_render_numeric_values() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: total_cost_usd=0.01234, total_duration_ms=45000,
+    // total_api_duration_ms=2300, total_lines_added=156, total_lines_removed=23
+    let output = cship()
+        .args(["--config", "tests/fixtures/cost_subfields.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0.0123"),
+        "expected '0.0123' in: {stdout:?}"
+    );
+    assert!(stdout.contains("45000"), "expected '45000' in: {stdout:?}");
+    assert!(stdout.contains("2300"), "expected '2300' in: {stdout:?}");
+    assert!(stdout.contains("156"), "expected '156' in: {stdout:?}");
+    assert!(stdout.contains("23"), "expected '23' in: {stdout:?}");
 }

--- a/tests/fixtures/cost_basic.toml
+++ b/tests/fixtures/cost_basic.toml
@@ -1,0 +1,4 @@
+[cship]
+lines = ["$cship.cost"]
+
+[cship.cost]

--- a/tests/fixtures/cost_critical.toml
+++ b/tests/fixtures/cost_critical.toml
@@ -1,0 +1,8 @@
+[cship]
+lines = ["$cship.cost"]
+
+[cship.cost]
+warn_threshold = 5.0
+warn_style = "yellow"
+critical_threshold = 10.0
+critical_style = "bold red"

--- a/tests/fixtures/cost_disabled.toml
+++ b/tests/fixtures/cost_disabled.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.cost"]
+
+[cship.cost]
+disabled = true

--- a/tests/fixtures/cost_high.json
+++ b/tests/fixtures/cost_high.json
@@ -1,0 +1,17 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "test-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "1.0.80",
+  "exceeds_200k_tokens": false,
+  "model": { "id": "claude-opus-4-6", "display_name": "Opus" },
+  "workspace": { "current_dir": "/home/user/projects/myapp", "project_dir": "/home/user/projects/myapp" },
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 12.0,
+    "total_duration_ms": 120000,
+    "total_api_duration_ms": 45000,
+    "total_lines_added": 500,
+    "total_lines_removed": 200
+  }
+}

--- a/tests/fixtures/cost_subfields.toml
+++ b/tests/fixtures/cost_subfields.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.cost.total_cost_usd $cship.cost.total_duration_ms $cship.cost.total_api_duration_ms $cship.cost.total_lines_added $cship.cost.total_lines_removed"]

--- a/tests/fixtures/cost_warn.toml
+++ b/tests/fixtures/cost_warn.toml
@@ -1,0 +1,8 @@
+[cship]
+lines = ["$cship.cost"]
+
+[cship.cost]
+warn_threshold = 5.0
+warn_style = "yellow"
+critical_threshold = 10.0
+critical_style = "bold red"

--- a/tests/fixtures/cost_warn_value.json
+++ b/tests/fixtures/cost_warn_value.json
@@ -1,0 +1,17 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "test-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "1.0.80",
+  "exceeds_200k_tokens": false,
+  "model": { "id": "claude-opus-4-6", "display_name": "Opus" },
+  "workspace": { "current_dir": "/home/user/projects/myapp", "project_dir": "/home/user/projects/myapp" },
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 6.0,
+    "total_duration_ms": 60000,
+    "total_api_duration_ms": 20000,
+    "total_lines_added": 200,
+    "total_lines_removed": 50
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `cship.cost` module rendering `total_cost_usd` as `$X.XX` format with warn/critical ANSI threshold styling
- Adds five sub-field modules (`cship.cost.total_cost_usd`, `total_duration_ms`, `total_api_duration_ms`, `total_lines_added`, `total_lines_removed`) for granular display control
- Extends `ansi.rs` with `apply_style_with_threshold` for reusable threshold-aware styling
- Adds Epic 2 config structs (`CostConfig`, `ContextBarConfig`, `ContextWindowConfig`, `VimConfig`, `AgentConfig`, `SessionConfig`, `WorkspaceConfig`) to `config.rs` for schema consistency across upcoming stories

## Test plan

- [x] `cargo test` passes all unit tests in `ansi.rs` (threshold logic) and `cost.rs` (render functions)
- [x] Integration tests in `tests/cli.rs` cover: basic dollar formatting, warn threshold ANSI, critical threshold ANSI, disabled output, and sub-field numeric values
- [x] `cost_disabled` config produces empty stdout
- [x] `cost_warn` config with value above warn threshold produces ANSI escape codes
- [x] `cost_critical` config with value above critical threshold produces ANSI escape codes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)