### PR TITLE
Add context window and context bar modules (Story 2.2)

### DIFF
--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -1,0 +1,219 @@
+use crate::config::CshipConfig;
+use crate::context::Context;
+
+const DEFAULT_BAR_WIDTH: u32 = 10;
+
+/// Renders `$cship.context_bar` — visual Unicode progress bar with threshold color escalation.
+/// Format: `{bar}{used_percentage:.0}%` e.g. `███░░░░░░░35%`
+/// Bar width is configurable via `[cship.context_bar].width` (default 10).
+///
+/// [Source: epics.md#Story 2.2, prd.md#FR8]
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let bar_cfg = cfg.context_bar.as_ref();
+
+    if bar_cfg.and_then(|c| c.disabled).unwrap_or(false) {
+        return None;
+    }
+
+    let used_pct = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.used_percentage)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_bar: used_percentage absent from context");
+            return None;
+        }
+    };
+
+    let width = bar_cfg.and_then(|c| c.width).unwrap_or(DEFAULT_BAR_WIDTH) as usize;
+    // Floor via `as usize` truncation — NOT round. The percentage text uses {:.0} (round).
+    // At boundary values like 99.5%, bar shows 9/10 filled while text shows "100%".
+    // This is intentional: the bar is a visual approximation, the number is canonical.
+    let filled = ((used_pct / 100.0) * width as f64) as usize;
+    let filled = filled.min(width); // guard floating-point edge at 100%
+    let empty = width - filled;
+
+    let bar: String = "█".repeat(filled) + &"░".repeat(empty);
+    let content = format!("{bar}{:.0}%", used_pct);
+
+    let style = bar_cfg.and_then(|c| c.style.as_deref());
+    let warn_threshold = bar_cfg.and_then(|c| c.warn_threshold);
+    let warn_style = bar_cfg.and_then(|c| c.warn_style.as_deref());
+    let critical_threshold = bar_cfg.and_then(|c| c.critical_threshold);
+    let critical_style = bar_cfg.and_then(|c| c.critical_style.as_deref());
+
+    Some(crate::ansi::apply_style_with_threshold(
+        &content,
+        Some(used_pct),
+        style,
+        warn_threshold,
+        warn_style,
+        critical_threshold,
+        critical_style,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ContextBarConfig, CshipConfig};
+    use crate::context::{Context, ContextWindow};
+
+    fn ctx_with_pct(pct: f64) -> Context {
+        Context {
+            context_window: Some(ContextWindow {
+                used_percentage: Some(pct),
+                remaining_percentage: Some(100.0 - pct),
+                context_window_size: Some(200000),
+                total_input_tokens: Some(15234),
+                total_output_tokens: Some(4521),
+                current_usage: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_context_bar_35_percent_3_filled_7_empty() {
+        let ctx = ctx_with_pct(35.0);
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        // 35% of 10 = 3.5 → floor → 3 filled, 7 empty → "███░░░░░░░35%"
+        let filled: usize = result.chars().filter(|&c| c == '█').count();
+        let empty: usize = result.chars().filter(|&c| c == '░').count();
+        assert_eq!(filled, 3, "expected 3 filled chars: {result:?}");
+        assert_eq!(empty, 7, "expected 7 empty chars: {result:?}");
+        assert!(result.contains("35%"), "expected '35%' in: {result:?}");
+    }
+
+    #[test]
+    fn test_context_bar_disabled_returns_none() {
+        let ctx = ctx_with_pct(50.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_context_bar_absent_context_window_returns_none() {
+        let ctx = Context::default();
+        assert_eq!(render(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_context_bar_custom_width_5() {
+        let ctx = ctx_with_pct(40.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                width: Some(5),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        // 40% of 5 = 2.0 → 2 filled, 3 empty
+        let total_bar: usize = result.chars().filter(|&c| c == '█' || c == '░').count();
+        assert_eq!(total_bar, 5, "expected total bar width 5: {result:?}");
+        assert_eq!(
+            result.chars().filter(|&c| c == '█').count(),
+            2,
+            "expected 2 filled: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_warn_threshold_applies_ansi() {
+        let ctx = ctx_with_pct(75.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(85.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for warn: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_critical_threshold_applies_ansi() {
+        let ctx = ctx_with_pct(90.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(85.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for critical: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_100_percent_all_filled() {
+        let ctx = ctx_with_pct(100.0);
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        assert!(
+            !result.contains('░'),
+            "expected no empty chars at 100%: {result:?}"
+        );
+        assert!(result.contains("100%"));
+    }
+
+    #[test]
+    fn test_context_bar_boundary_15_percent_floors_to_1_filled() {
+        let ctx = ctx_with_pct(15.0);
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        // 15% of 10 = 1.5 → floor → 1 filled, 9 empty (NOT round → 2)
+        let filled: usize = result.chars().filter(|&c| c == '█').count();
+        let empty: usize = result.chars().filter(|&c| c == '░').count();
+        assert_eq!(filled, 1, "15% should floor to 1 filled: {result:?}");
+        assert_eq!(empty, 9, "15% should leave 9 empty: {result:?}");
+        assert!(result.contains("15%"), "expected '15%' in: {result:?}");
+    }
+
+    #[test]
+    fn test_context_bar_boundary_99_5_percent_floors_to_9_filled() {
+        let ctx = ctx_with_pct(99.5);
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        // 99.5% of 10 = 9.95 → floor → 9 filled, 1 empty; text rounds to "100%"
+        let filled: usize = result.chars().filter(|&c| c == '█').count();
+        let empty: usize = result.chars().filter(|&c| c == '░').count();
+        assert_eq!(filled, 9, "99.5% should floor to 9 filled: {result:?}");
+        assert_eq!(empty, 1, "99.5% should leave 1 empty: {result:?}");
+        // {:.0} rounds 99.5 to "100" (banker's rounding) — this is expected
+        assert!(
+            result.contains("100%") || result.contains("99%"),
+            "expected rounded percentage in: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_0_percent_all_empty() {
+        let ctx = ctx_with_pct(0.0);
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        assert!(
+            !result.contains('█'),
+            "expected no filled chars at 0%: {result:?}"
+        );
+        assert!(result.contains("0%"));
+    }
+}

--- a/src/modules/context_window.rs
+++ b/src/modules/context_window.rs
@@ -1,0 +1,401 @@
+use crate::config::CshipConfig;
+use crate::context::Context;
+
+const DEFAULT_EXCEEDS_SYMBOL: &str = ">200k";
+
+fn is_disabled(cfg: &CshipConfig) -> bool {
+    cfg.context_window
+        .as_ref()
+        .and_then(|c| c.disabled)
+        .unwrap_or(false)
+}
+
+fn apply_cw_style(content: &str, cfg: &CshipConfig) -> String {
+    crate::ansi::apply_style(
+        content,
+        cfg.context_window.as_ref().and_then(|c| c.style.as_deref()),
+    )
+}
+
+/// Renders `$cship.context_window.used_percentage` — integer percentage, no `%` sign.
+pub fn render_used_percentage(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.used_percentage)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_window.used_percentage: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_cw_style(&format!("{:.0}", val), cfg))
+}
+
+/// Renders `$cship.context_window.remaining_percentage` — integer percentage, no `%` sign.
+pub fn render_remaining_percentage(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.remaining_percentage)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_window.remaining_percentage: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_cw_style(&format!("{:.0}", val), cfg))
+}
+
+/// Renders `$cship.context_window.size` — reads `context_window_size` field (not `size`).
+pub fn render_size(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.context_window_size)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_window.size: context_window_size absent from context");
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.total_input_tokens`.
+pub fn render_total_input_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.total_input_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_window.total_input_tokens: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.total_output_tokens`.
+pub fn render_total_output_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.total_output_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!("cship.context_window.total_output_tokens: value absent from context");
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.exceeds_200k`.
+///
+/// CRITICAL: `exceeds_200k_tokens` is a TOP-LEVEL field on `Context`, NOT inside `context_window`.
+/// Returns None when false or absent (no tracing::warn! — false is a valid expected state).
+/// When true, renders configurable symbol (default: ">200k").
+pub fn render_exceeds_200k(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let exceeds = ctx.exceeds_200k_tokens.unwrap_or(false);
+    if !exceeds {
+        return None; // false is normal — no warn
+    }
+    let symbol = cfg
+        .context_window
+        .as_ref()
+        .and_then(|c| c.symbol.as_deref())
+        .unwrap_or(DEFAULT_EXCEEDS_SYMBOL);
+    Some(apply_cw_style(symbol, cfg))
+}
+
+/// Renders `$cship.context_window.current_usage.input_tokens`.
+pub fn render_current_usage_input_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.current_usage.as_ref())
+        .and_then(|cu| cu.input_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                "cship.context_window.current_usage.input_tokens: value absent from context"
+            );
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.current_usage.output_tokens`.
+pub fn render_current_usage_output_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.current_usage.as_ref())
+        .and_then(|cu| cu.output_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                "cship.context_window.current_usage.output_tokens: value absent from context"
+            );
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.current_usage.cache_creation_input_tokens`.
+pub fn render_current_usage_cache_creation_input_tokens(
+    ctx: &Context,
+    cfg: &CshipConfig,
+) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.current_usage.as_ref())
+        .and_then(|cu| cu.cache_creation_input_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                "cship.context_window.current_usage.cache_creation_input_tokens: value absent from context"
+            );
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+/// Renders `$cship.context_window.current_usage.cache_read_input_tokens`.
+pub fn render_current_usage_cache_read_input_tokens(
+    ctx: &Context,
+    cfg: &CshipConfig,
+) -> Option<String> {
+    if is_disabled(cfg) {
+        return None;
+    }
+    let val = match ctx
+        .context_window
+        .as_ref()
+        .and_then(|cw| cw.current_usage.as_ref())
+        .and_then(|cu| cu.cache_read_input_tokens)
+    {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                "cship.context_window.current_usage.cache_read_input_tokens: value absent from context"
+            );
+            return None;
+        }
+    };
+    Some(apply_cw_style(&val.to_string(), cfg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ContextWindowConfig, CshipConfig};
+    use crate::context::{Context, ContextWindow, CurrentUsage};
+
+    fn ctx_full() -> Context {
+        Context {
+            exceeds_200k_tokens: Some(false),
+            context_window: Some(ContextWindow {
+                used_percentage: Some(35.0),
+                remaining_percentage: Some(65.0),
+                context_window_size: Some(200000),
+                total_input_tokens: Some(15234),
+                total_output_tokens: Some(4521),
+                current_usage: Some(CurrentUsage {
+                    input_tokens: Some(8500),
+                    output_tokens: Some(1200),
+                    cache_creation_input_tokens: Some(5000),
+                    cache_read_input_tokens: Some(2000),
+                }),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_used_percentage_renders_as_integer_no_percent_sign() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_used_percentage(&ctx, &CshipConfig::default()),
+            Some("35".to_string())
+        );
+    }
+
+    #[test]
+    fn test_remaining_percentage_renders_as_integer() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_remaining_percentage(&ctx, &CshipConfig::default()),
+            Some("65".to_string())
+        );
+    }
+
+    #[test]
+    fn test_size_reads_context_window_size_field() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_size(&ctx, &CshipConfig::default()),
+            Some("200000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_total_input_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_total_input_tokens(&ctx, &CshipConfig::default()),
+            Some("15234".to_string())
+        );
+    }
+
+    #[test]
+    fn test_total_output_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_total_output_tokens(&ctx, &CshipConfig::default()),
+            Some("4521".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exceeds_200k_false_returns_none_no_warn() {
+        let ctx = ctx_full(); // exceeds_200k_tokens = false
+        assert_eq!(render_exceeds_200k(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_exceeds_200k_absent_treated_as_false() {
+        let ctx = Context::default(); // exceeds_200k_tokens = None
+        assert_eq!(render_exceeds_200k(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_exceeds_200k_true_renders_default_symbol() {
+        let ctx = Context {
+            exceeds_200k_tokens: Some(true),
+            ..Default::default()
+        };
+        let result = render_exceeds_200k(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some(">200k".to_string()));
+    }
+
+    #[test]
+    fn test_current_usage_input_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_current_usage_input_tokens(&ctx, &CshipConfig::default()),
+            Some("8500".to_string())
+        );
+    }
+
+    #[test]
+    fn test_current_usage_output_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_current_usage_output_tokens(&ctx, &CshipConfig::default()),
+            Some("1200".to_string())
+        );
+    }
+
+    #[test]
+    fn test_current_usage_cache_creation_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_current_usage_cache_creation_input_tokens(&ctx, &CshipConfig::default()),
+            Some("5000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_current_usage_cache_read_tokens() {
+        let ctx = ctx_full();
+        assert_eq!(
+            render_current_usage_cache_read_input_tokens(&ctx, &CshipConfig::default()),
+            Some("2000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exceeds_200k_true_renders_custom_symbol() {
+        let ctx = Context {
+            exceeds_200k_tokens: Some(true),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            context_window: Some(ContextWindowConfig {
+                symbol: Some("⚠".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render_exceeds_200k(&ctx, &cfg);
+        assert_eq!(result, Some("⚠".to_string()));
+    }
+
+    #[test]
+    fn test_disabled_flag_suppresses_all_renders() {
+        let ctx = ctx_full();
+        let cfg = CshipConfig {
+            context_window: Some(ContextWindowConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render_used_percentage(&ctx, &cfg), None);
+        assert_eq!(render_size(&ctx, &cfg), None);
+        assert_eq!(render_exceeds_200k(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_absent_context_window_returns_none() {
+        let ctx = Context::default(); // no context_window
+        assert_eq!(render_used_percentage(&ctx, &CshipConfig::default()), None);
+        assert_eq!(render_size(&ctx, &CshipConfig::default()), None);
+        assert_eq!(
+            render_total_input_tokens(&ctx, &CshipConfig::default()),
+            None
+        );
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,5 @@
+pub mod context_bar;
+pub mod context_window;
 pub mod cost;
 pub mod model;
 
@@ -17,6 +19,33 @@ pub fn render_module(
         "cship.cost.total_api_duration_ms" => cost::render_total_api_duration_ms(ctx, cfg),
         "cship.cost.total_lines_added" => cost::render_total_lines_added(ctx, cfg),
         "cship.cost.total_lines_removed" => cost::render_total_lines_removed(ctx, cfg),
+        // Context bar — progress bar with threshold styling
+        "cship.context_bar" => context_bar::render(ctx, cfg),
+        // Context window sub-fields
+        "cship.context_window.used_percentage" => context_window::render_used_percentage(ctx, cfg),
+        "cship.context_window.remaining_percentage" => {
+            context_window::render_remaining_percentage(ctx, cfg)
+        }
+        "cship.context_window.size" => context_window::render_size(ctx, cfg),
+        "cship.context_window.total_input_tokens" => {
+            context_window::render_total_input_tokens(ctx, cfg)
+        }
+        "cship.context_window.total_output_tokens" => {
+            context_window::render_total_output_tokens(ctx, cfg)
+        }
+        "cship.context_window.exceeds_200k" => context_window::render_exceeds_200k(ctx, cfg),
+        "cship.context_window.current_usage.input_tokens" => {
+            context_window::render_current_usage_input_tokens(ctx, cfg)
+        }
+        "cship.context_window.current_usage.output_tokens" => {
+            context_window::render_current_usage_output_tokens(ctx, cfg)
+        }
+        "cship.context_window.current_usage.cache_creation_input_tokens" => {
+            context_window::render_current_usage_cache_creation_input_tokens(ctx, cfg)
+        }
+        "cship.context_window.current_usage.cache_read_input_tokens" => {
+            context_window::render_current_usage_cache_read_input_tokens(ctx, cfg)
+        }
         other => {
             tracing::warn!("cship: unknown native module '{other}' — skipping");
             None

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -290,3 +290,178 @@ fn test_cost_subfields_render_numeric_values() {
     assert!(stdout.contains("156"), "expected '156' in: {stdout:?}");
     assert!(stdout.contains("23"), "expected '23' in: {stdout:?}");
 }
+
+// ── Story 2.2: Context window modules integration tests ───────────────────
+
+#[test]
+fn test_context_bar_renders_block_chars_and_percentage() {
+    let json = std::fs::read_to_string("tests/fixtures/context_high.json").unwrap();
+    // context_high.json: used_percentage = 90.0 → "█████████░90%"
+    let output = cship()
+        .args(["--config", "tests/fixtures/context_bar_basic.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('█'),
+        "expected filled bar chars: {stdout:?}"
+    );
+    assert!(stdout.contains("90%"), "expected '90%': {stdout:?}");
+}
+
+#[test]
+fn test_context_bar_warn_threshold_applies_ansi_style() {
+    let json = std::fs::read_to_string("tests/fixtures/context_warn.json").unwrap();
+    // context_warn.json: used_percentage = 75.0 > warn_threshold 70.0 → ANSI codes
+    cship()
+        .args(["--config", "tests/fixtures/context_bar_warn.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["));
+}
+
+#[test]
+fn test_context_bar_critical_threshold_applies_critical_style() {
+    let json = std::fs::read_to_string("tests/fixtures/context_high.json").unwrap();
+    // context_high.json: used_percentage = 90.0 > critical_threshold 85.0 → ANSI codes
+    cship()
+        .args(["--config", "tests/fixtures/context_bar_warn.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["));
+}
+
+#[test]
+fn test_context_bar_disabled_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/context_bar_disabled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_context_bar_custom_width_5() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: used_percentage = 8.0; width 5 → 0 filled, 5 empty
+    let output = cship()
+        .args(["--config", "tests/fixtures/context_bar_width.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let total_bar: usize = stdout.chars().filter(|&c| c == '█' || c == '░').count();
+    assert_eq!(total_bar, 5, "expected bar width 5 in: {stdout:?}");
+    // sample_input_full.json: used_percentage = 8.0; floor(8% of 5) = 0 filled, 5 empty
+    let filled: usize = stdout.chars().filter(|&c| c == '█').count();
+    let empty: usize = stdout.chars().filter(|&c| c == '░').count();
+    assert_eq!(
+        filled, 0,
+        "expected 0 filled for 8% with width 5: {stdout:?}"
+    );
+    assert_eq!(empty, 5, "expected 5 empty for 8% with width 5: {stdout:?}");
+}
+
+#[test]
+fn test_context_window_subfields_render_correctly() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: used_percentage=8, remaining_percentage=92, context_window_size=200000
+    let output = cship()
+        .args(["--config", "tests/fixtures/context_window_basic.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Output format: "8 92 200000\n" — verify each value appears as a space-delimited token
+    let tokens: Vec<&str> = stdout.trim().split_whitespace().collect();
+    assert_eq!(
+        tokens.len(),
+        3,
+        "expected 3 space-separated tokens: {stdout:?}"
+    );
+    assert_eq!(tokens[0], "8", "expected used_pct '8': {stdout:?}");
+    assert_eq!(tokens[1], "92", "expected remaining_pct '92': {stdout:?}");
+    assert_eq!(
+        tokens[2], "200000",
+        "expected window size '200000': {stdout:?}"
+    );
+}
+
+#[test]
+fn test_context_window_exceeds_200k_false_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: exceeds_200k_tokens = false → empty output
+    cship()
+        .args(["--config", "tests/fixtures/context_window_exceeds.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_context_window_exceeds_200k_true_renders_marker() {
+    let json = std::fs::read_to_string("tests/fixtures/context_high.json").unwrap();
+    // context_high.json: exceeds_200k_tokens = true → ">200k"
+    cship()
+        .args(["--config", "tests/fixtures/context_window_exceeds.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(">200k"));
+}
+
+#[test]
+fn test_context_window_current_usage_tokens() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: current_usage.input_tokens=8500, output_tokens=1200
+    let output = cship()
+        .args([
+            "--config",
+            "tests/fixtures/context_window_current_usage.toml",
+        ])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("8500"),
+        "expected input_tokens in: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("1200"),
+        "expected output_tokens in: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_context_window_total_tokens_render_correctly() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: total_input_tokens=15234, total_output_tokens=4521
+    let output = cship()
+        .args(["--config", "tests/fixtures/context_window_totals.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let tokens: Vec<&str> = stdout.trim().split_whitespace().collect();
+    assert_eq!(tokens.len(), 2, "expected 2 tokens: {stdout:?}");
+    assert_eq!(
+        tokens[0], "15234",
+        "expected total_input_tokens: {stdout:?}"
+    );
+    assert_eq!(
+        tokens[1], "4521",
+        "expected total_output_tokens: {stdout:?}"
+    );
+}

--- a/tests/fixtures/context_bar_basic.toml
+++ b/tests/fixtures/context_bar_basic.toml
@@ -1,0 +1,4 @@
+[cship]
+lines = ["$cship.context_bar"]
+
+[cship.context_bar]

--- a/tests/fixtures/context_bar_disabled.toml
+++ b/tests/fixtures/context_bar_disabled.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.context_bar"]
+
+[cship.context_bar]
+disabled = true

--- a/tests/fixtures/context_bar_warn.toml
+++ b/tests/fixtures/context_bar_warn.toml
@@ -1,0 +1,8 @@
+[cship]
+lines = ["$cship.context_bar"]
+
+[cship.context_bar]
+warn_threshold = 70.0
+warn_style = "yellow"
+critical_threshold = 85.0
+critical_style = "bold red"

--- a/tests/fixtures/context_bar_width.toml
+++ b/tests/fixtures/context_bar_width.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.context_bar"]
+
+[cship.context_bar]
+width = 5

--- a/tests/fixtures/context_high.json
+++ b/tests/fixtures/context_high.json
@@ -1,0 +1,30 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "test-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "1.0.80",
+  "exceeds_200k_tokens": true,
+  "model": { "id": "claude-opus-4-6", "display_name": "Opus" },
+  "workspace": { "current_dir": "/home/user/projects/myapp", "project_dir": "/home/user/projects/myapp" },
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 2.50,
+    "total_duration_ms": 900000,
+    "total_api_duration_ms": 450000,
+    "total_lines_added": 1200,
+    "total_lines_removed": 800
+  },
+  "context_window": {
+    "total_input_tokens": 180000,
+    "total_output_tokens": 20000,
+    "context_window_size": 200000,
+    "used_percentage": 90.0,
+    "remaining_percentage": 10.0,
+    "current_usage": {
+      "input_tokens": 45000,
+      "output_tokens": 5000,
+      "cache_creation_input_tokens": 30000,
+      "cache_read_input_tokens": 10000
+    }
+  }
+}

--- a/tests/fixtures/context_warn.json
+++ b/tests/fixtures/context_warn.json
@@ -1,0 +1,30 @@
+{
+  "cwd": "/home/user/projects/myapp",
+  "session_id": "test-session-id",
+  "transcript_path": "/home/user/.claude/projects/myapp/transcript.jsonl",
+  "version": "1.0.80",
+  "exceeds_200k_tokens": false,
+  "model": { "id": "claude-opus-4-6", "display_name": "Opus" },
+  "workspace": { "current_dir": "/home/user/projects/myapp", "project_dir": "/home/user/projects/myapp" },
+  "output_style": { "name": "default" },
+  "cost": {
+    "total_cost_usd": 1.20,
+    "total_duration_ms": 500000,
+    "total_api_duration_ms": 250000,
+    "total_lines_added": 600,
+    "total_lines_removed": 300
+  },
+  "context_window": {
+    "total_input_tokens": 150000,
+    "total_output_tokens": 15000,
+    "context_window_size": 200000,
+    "used_percentage": 75.0,
+    "remaining_percentage": 25.0,
+    "current_usage": {
+      "input_tokens": 20000,
+      "output_tokens": 3000,
+      "cache_creation_input_tokens": 15000,
+      "cache_read_input_tokens": 5000
+    }
+  }
+}

--- a/tests/fixtures/context_window_basic.toml
+++ b/tests/fixtures/context_window_basic.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.context_window.used_percentage $cship.context_window.remaining_percentage $cship.context_window.size"]

--- a/tests/fixtures/context_window_current_usage.toml
+++ b/tests/fixtures/context_window_current_usage.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.context_window.current_usage.input_tokens $cship.context_window.current_usage.output_tokens"]

--- a/tests/fixtures/context_window_exceeds.toml
+++ b/tests/fixtures/context_window_exceeds.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.context_window.exceeds_200k"]

--- a/tests/fixtures/context_window_totals.toml
+++ b/tests/fixtures/context_window_totals.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.context_window.total_input_tokens $cship.context_window.total_output_tokens"]


### PR DESCRIPTION
## Summary
- Add `context_bar` module rendering a Unicode block progress bar with warn/critical threshold styling
- Add `context_window` module exposing all context window sub-fields (used/remaining percentage, size, total tokens, exceeds_200k, current usage tokens)
- Register all new module keys in `render_module` dispatcher
- Add comprehensive integration tests and fixture files

Closes #14

## Test plan
- [x] `cargo test` — all new integration tests pass
- [x] Verify context bar renders filled/empty blocks proportional to usage
- [x] Verify warn and critical ANSI styles applied at thresholds
- [x] Verify disabled context bar produces no output
- [x] Verify custom bar width renders correct number of blocks
- [x] Verify all context_window sub-fields render correct numeric values
- [x] Verify `exceeds_200k` renders marker only when true

🤖 Generated with [Claude Code](https://claude.com/claude-code)