### PR TITLE
Add vim and agent modules (Story 2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _bmad*
 # Added by cargo
 
 /target
+starship.toml

--- a/src/modules/agent.rs
+++ b/src/modules/agent.rs
@@ -1,0 +1,111 @@
+/// Render the `[cship.agent]` module.
+///
+/// `$cship.agent` — convenience alias for `$cship.agent.name`.
+/// `$cship.agent.name` — raw agent name string (e.g., "claude-code", "security-reviewer").
+///
+/// [Source: epics.md#Story 2.3, architecture.md#Module System Architecture]
+use crate::config::CshipConfig;
+use crate::context::Context;
+
+/// Renders `$cship.agent` — convenience alias for agent name.
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_name(ctx, cfg)
+}
+
+/// Renders `$cship.agent.name` — raw agent name string with optional symbol and style.
+pub fn render_name(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    // Disabled check — SILENT (no warn, no log)
+    if cfg.agent.as_ref().and_then(|a| a.disabled).unwrap_or(false) {
+        return None;
+    }
+
+    // Extract value — WARN before returning None (AC8 requirement)
+    let name = match ctx.agent.as_ref().and_then(|a| a.name.as_ref()) {
+        Some(n) => n,
+        None => {
+            tracing::warn!("cship.agent: name absent from context");
+            return None;
+        }
+    };
+
+    // Apply symbol + style
+    let agent_cfg = cfg.agent.as_ref();
+    let symbol = agent_cfg.and_then(|a| a.symbol.as_deref()).unwrap_or("");
+    let content = format!("{symbol}{name}");
+    let style = agent_cfg.and_then(|a| a.style.as_deref());
+
+    Some(crate::ansi::apply_style(&content, style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AgentConfig, CshipConfig};
+    use crate::context::{Agent, Context};
+
+    fn ctx_with_agent(name: &str) -> Context {
+        Context {
+            agent: Some(Agent {
+                name: Some(name.to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_agent_renders_name_string() {
+        let ctx = ctx_with_agent("claude-code");
+        let result = render(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("claude-code".to_string()));
+    }
+
+    #[test]
+    fn test_agent_name_alias_identical_to_render() {
+        let ctx = ctx_with_agent("security-reviewer");
+        let r1 = render(&ctx, &CshipConfig::default());
+        let r2 = render_name(&ctx, &CshipConfig::default());
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_agent_disabled_returns_none() {
+        let ctx = ctx_with_agent("claude-code");
+        let cfg = CshipConfig {
+            agent: Some(AgentConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_agent_absent_returns_none() {
+        let ctx = Context::default(); // no agent field
+        assert_eq!(render(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_agent_applies_symbol_and_style() {
+        let ctx = ctx_with_agent("security-reviewer");
+        let cfg = CshipConfig {
+            agent: Some(AgentConfig {
+                symbol: Some("🤖 ".to_string()),
+                style: Some("bold cyan".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains("security-reviewer"),
+            "should contain name: {result:?}"
+        );
+        assert!(result.contains("🤖 "), "should contain symbol: {result:?}");
+        assert!(
+            result.contains('\x1b'),
+            "should contain ANSI codes: {result:?}"
+        );
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,7 +1,9 @@
+pub mod agent;
 pub mod context_bar;
 pub mod context_window;
 pub mod cost;
 pub mod model;
+pub mod vim;
 
 /// Static dispatch registry — the ONLY file modified when adding a new native module.
 /// [Source: architecture.md#Module System Architecture]
@@ -12,6 +14,8 @@ pub fn render_module(
 ) -> Option<String> {
     match name {
         "cship.model" => model::render(ctx, cfg),
+        "cship.model.display_name" => model::render_display_name(ctx, cfg),
+        "cship.model.id" => model::render_id(ctx, cfg),
         // Cost module — main alias and sub-fields
         "cship.cost" => cost::render(ctx, cfg),
         "cship.cost.total_cost_usd" => cost::render_total_cost_usd(ctx, cfg),
@@ -46,6 +50,12 @@ pub fn render_module(
         "cship.context_window.current_usage.cache_read_input_tokens" => {
             context_window::render_current_usage_cache_read_input_tokens(ctx, cfg)
         }
+        // Vim module — mode display
+        "cship.vim" => vim::render(ctx, cfg),
+        "cship.vim.mode" => vim::render_mode(ctx, cfg),
+        // Agent module — agent name display
+        "cship.agent" => agent::render(ctx, cfg),
+        "cship.agent.name" => agent::render_name(ctx, cfg),
         other => {
             tracing::warn!("cship: unknown native module '{other}' — skipping");
             None

--- a/src/modules/model.rs
+++ b/src/modules/model.rs
@@ -29,6 +29,36 @@ pub fn render(ctx: &crate::context::Context, cfg: &crate::config::CshipConfig) -
     Some(crate::ansi::apply_style(&content, style))
 }
 
+/// Renders `$cship.model.display_name` — explicit sub-field alias for `render`.
+pub fn render_display_name(
+    ctx: &crate::context::Context,
+    cfg: &crate::config::CshipConfig,
+) -> Option<String> {
+    render(ctx, cfg)
+}
+
+/// Renders `$cship.model.id` — raw model ID string (e.g., "claude-opus-4-6").
+pub fn render_id(
+    ctx: &crate::context::Context,
+    cfg: &crate::config::CshipConfig,
+) -> Option<String> {
+    let model_cfg = cfg.model.as_ref();
+    if model_cfg.and_then(|m| m.disabled).unwrap_or(false) {
+        return None;
+    }
+    let id = match ctx.model.as_ref().and_then(|m| m.id.as_deref()) {
+        Some(id) => id,
+        None => {
+            tracing::warn!("cship.model: model.id is absent — skipping");
+            return None;
+        }
+    };
+    let symbol = model_cfg.and_then(|m| m.symbol.as_deref()).unwrap_or("");
+    let content = format!("{symbol}{id}");
+    let style = model_cfg.and_then(|m| m.style.as_deref());
+    Some(crate::ansi::apply_style(&content, style))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,5 +154,45 @@ mod tests {
         let ctx = ctx_with_model("Sonnet");
         let result = render(&ctx, &CshipConfig::default()).unwrap();
         assert_eq!(result, "Sonnet");
+    }
+
+    #[test]
+    fn test_render_id_returns_model_id() {
+        let ctx = Context {
+            model: Some(Model {
+                id: Some("claude-opus-4-6".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render_id(&ctx, &CshipConfig::default()),
+            Some("claude-opus-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_id_absent_returns_none() {
+        let ctx = Context::default();
+        assert_eq!(render_id(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_render_id_disabled_returns_none() {
+        let ctx = Context {
+            model: Some(Model {
+                id: Some("claude-opus-4-6".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render_id(&ctx, &cfg), None);
     }
 }

--- a/src/modules/vim.rs
+++ b/src/modules/vim.rs
@@ -1,0 +1,108 @@
+/// Render the `[cship.vim]` module.
+///
+/// `$cship.vim` — convenience alias for `$cship.vim.mode`.
+/// `$cship.vim.mode` — raw vim mode string (e.g., "NORMAL", "INSERT").
+///
+/// [Source: epics.md#Story 2.3, architecture.md#Module System Architecture]
+use crate::config::CshipConfig;
+use crate::context::Context;
+
+/// Renders `$cship.vim` — convenience alias for vim mode.
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_mode(ctx, cfg)
+}
+
+/// Renders `$cship.vim.mode` — raw vim mode string with optional symbol and style.
+pub fn render_mode(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    // Disabled check — SILENT (no warn, no log)
+    if cfg.vim.as_ref().and_then(|v| v.disabled).unwrap_or(false) {
+        return None;
+    }
+
+    // Extract value — WARN before returning None (AC3 requirement)
+    let mode = match ctx.vim.as_ref().and_then(|v| v.mode.as_ref()) {
+        Some(m) => m,
+        None => {
+            tracing::warn!("cship.vim: mode absent from context");
+            return None;
+        }
+    };
+
+    // Apply symbol + style
+    let vim_cfg = cfg.vim.as_ref();
+    let symbol = vim_cfg.and_then(|v| v.symbol.as_deref()).unwrap_or("");
+    let content = format!("{symbol}{mode}");
+    let style = vim_cfg.and_then(|v| v.style.as_deref());
+
+    Some(crate::ansi::apply_style(&content, style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CshipConfig, VimConfig};
+    use crate::context::{Context, Vim};
+
+    fn ctx_with_vim(mode: &str) -> Context {
+        Context {
+            vim: Some(Vim {
+                mode: Some(mode.to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_vim_renders_mode_string() {
+        let ctx = ctx_with_vim("NORMAL");
+        let result = render(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("NORMAL".to_string()));
+    }
+
+    #[test]
+    fn test_vim_mode_alias_identical_to_render() {
+        let ctx = ctx_with_vim("VISUAL");
+        let r1 = render(&ctx, &CshipConfig::default());
+        let r2 = render_mode(&ctx, &CshipConfig::default());
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_vim_disabled_returns_none() {
+        let ctx = ctx_with_vim("NORMAL");
+        let cfg = CshipConfig {
+            vim: Some(VimConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_vim_absent_returns_none() {
+        let ctx = Context::default(); // no vim field
+        assert_eq!(render(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_vim_applies_symbol_and_style() {
+        let ctx = ctx_with_vim("INSERT");
+        let cfg = CshipConfig {
+            vim: Some(VimConfig {
+                symbol: Some("✏ ".to_string()),
+                style: Some("bold yellow".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains("INSERT"), "should contain mode: {result:?}");
+        assert!(result.contains("✏ "), "should contain symbol: {result:?}");
+        assert!(
+            result.contains('\x1b'),
+            "should contain ANSI codes: {result:?}"
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -465,3 +465,112 @@ fn test_context_window_total_tokens_render_correctly() {
         "expected total_output_tokens: {stdout:?}"
     );
 }
+
+// ── Story 2.3: Vim and Agent modules integration tests ────────────────────
+
+#[test]
+fn test_vim_renders_mode_string() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: vim.mode = "NORMAL"
+    cship()
+        .args(["--config", "tests/fixtures/vim_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NORMAL"));
+}
+
+#[test]
+fn test_vim_applies_symbol_and_style() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // vim_styled.toml: symbol = "✏ ", style = "bold yellow" → ANSI codes present
+    cship()
+        .args(["--config", "tests/fixtures/vim_styled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["))
+        .stdout(predicate::str::contains("✏ "));
+}
+
+#[test]
+fn test_vim_disabled_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/vim_disabled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_vim_absent_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_minimal.json").unwrap();
+    // sample_input_minimal.json has no vim field → empty render
+    cship()
+        .args(["--config", "tests/fixtures/vim_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_vim_mode_subfield_renders_identically() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // vim_mode_subfield.toml: lines = ["$cship.vim.mode"] → same as $cship.vim
+    cship()
+        .args(["--config", "tests/fixtures/vim_mode_subfield.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NORMAL"));
+}
+
+#[test]
+fn test_agent_renders_name_string() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: agent.name = "security-reviewer"
+    cship()
+        .args(["--config", "tests/fixtures/agent_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("security-reviewer"));
+}
+
+#[test]
+fn test_agent_name_subfield_renders_identically() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // agent_name_subfield.toml: lines = ["$cship.agent.name"] → same as $cship.agent
+    cship()
+        .args(["--config", "tests/fixtures/agent_name_subfield.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("security-reviewer"));
+}
+
+#[test]
+fn test_agent_disabled_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/agent_disabled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_agent_absent_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_minimal.json").unwrap();
+    // sample_input_minimal.json has no agent field → empty render
+    cship()
+        .args(["--config", "tests/fixtures/agent_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}

--- a/tests/fixtures/agent_basic.toml
+++ b/tests/fixtures/agent_basic.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.agent"]

--- a/tests/fixtures/agent_disabled.toml
+++ b/tests/fixtures/agent_disabled.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.agent"]
+
+[cship.agent]
+disabled = true

--- a/tests/fixtures/agent_name_subfield.toml
+++ b/tests/fixtures/agent_name_subfield.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.agent.name"]

--- a/tests/fixtures/vim_basic.toml
+++ b/tests/fixtures/vim_basic.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.vim"]

--- a/tests/fixtures/vim_disabled.toml
+++ b/tests/fixtures/vim_disabled.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.vim"]
+
+[cship.vim]
+disabled = true

--- a/tests/fixtures/vim_mode_subfield.toml
+++ b/tests/fixtures/vim_mode_subfield.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.vim.mode"]

--- a/tests/fixtures/vim_styled.toml
+++ b/tests/fixtures/vim_styled.toml
@@ -1,0 +1,6 @@
+[cship]
+lines = ["$cship.vim"]
+
+[cship.vim]
+symbol = "✏ "
+style = "bold yellow"


### PR DESCRIPTION
## Summary
- Add `cship.vim` / `cship.vim.mode` module rendering vim mode string (NORMAL, INSERT, etc.) with symbol + style support
- Add `cship.agent` / `cship.agent.name` module rendering active agent name with symbol + style support
- Add `cship.model.display_name` and `cship.model.id` sub-field aliases for the model module
- Register all new module paths in the static dispatch registry

## Test plan
- [x] 86 unit tests pass (`cargo test`)
- [x] 41 integration tests pass (CLI end-to-end)
- [x] `cargo clippy -- -D warnings` exits clean
- [x] Vim: basic render, styled, disabled, absent, mode sub-field
- [x] Agent: basic render, disabled, absent, name sub-field
- [x] Model: `render_id` and `render_display_name` sub-fields

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)