### PR TITLE
Fix threshold styles ignored when format string is set (Story 2.6) (#38)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -72,6 +72,34 @@ pub fn apply_style_with_threshold(
     apply_style(content, style)
 }
 
+/// Resolve the effective style string based on numeric thresholds — without painting content.
+/// Returns `critical_style` if `value` >= `critical_threshold` (both Some).
+/// Returns `warn_style` if `value` >= `warn_threshold` (both Some).
+/// Otherwise returns base `style`.
+/// Used by modules that apply format strings but still need threshold-escalated style.
+///
+/// [Source: epics.md#Story 2.6]
+pub fn resolve_threshold_style<'a>(
+    value: Option<f64>,
+    style: Option<&'a str>,
+    warn_threshold: Option<f64>,
+    warn_style: Option<&'a str>,
+    critical_threshold: Option<f64>,
+    critical_style: Option<&'a str>,
+) -> Option<&'a str> {
+    if let (Some(val), Some(thresh), Some(crit)) = (value, critical_threshold, critical_style)
+        && val >= thresh
+    {
+        return Some(crit);
+    }
+    if let (Some(val), Some(thresh), Some(warn)) = (value, warn_threshold, warn_style)
+        && val >= thresh
+    {
+        return Some(warn);
+    }
+    style
+}
+
 /// Strip ANSI escape sequences from a string, returning plain text.
 /// Used by `cship explain` to display module values in a readable table.
 pub fn strip_ansi(s: &str) -> String {
@@ -207,5 +235,84 @@ mod tests {
         let result =
             apply_style_with_threshold("text", Some(100.0), Some("green"), None, None, None, None);
         assert!(result.contains('\x1b'), "expected base style ANSI");
+    }
+
+    #[test]
+    fn test_resolve_threshold_below_warn_returns_base() {
+        let result = resolve_threshold_style(
+            Some(3.0),
+            Some("green"),
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, Some("green"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_above_warn_returns_warn() {
+        let result = resolve_threshold_style(
+            Some(6.0),
+            Some("green"),
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, Some("yellow"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_above_critical_returns_critical() {
+        let result = resolve_threshold_style(
+            Some(12.0),
+            Some("green"),
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, Some("red"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_value_none_returns_base() {
+        let result = resolve_threshold_style(
+            None,
+            Some("green"),
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, Some("green"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_no_thresholds_returns_base() {
+        let result = resolve_threshold_style(Some(100.0), Some("green"), None, None, None, None);
+        assert_eq!(result, Some("green"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_warn_style_none_falls_through_to_base() {
+        // warn_threshold set but warn_style is None → cannot escalate, returns base
+        let result = resolve_threshold_style(Some(6.0), Some("green"), Some(5.0), None, None, None);
+        assert_eq!(result, Some("green"));
+    }
+
+    #[test]
+    fn test_resolve_threshold_at_exact_boundary_triggers() {
+        // value == warn_threshold → >= fires, returns warn_style
+        let result = resolve_threshold_style(
+            Some(5.0),
+            Some("green"),
+            Some(5.0),
+            Some("yellow"),
+            Some(10.0),
+            Some("red"),
+        );
+        assert_eq!(result, Some("yellow"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,8 +26,6 @@ pub struct ModelConfig {
     pub disabled: Option<bool>,
     /// When `true`, prepends the module name as a label.
     pub label: Option<bool>,
-    pub warn_threshold: Option<f64>,
-    pub critical_threshold: Option<f64>,
     pub format: Option<String>,
 }
 
@@ -285,8 +283,6 @@ mod tests {
         let model = cfg.model.as_ref().unwrap();
         assert!(model.style.is_some(), "model.style should be present");
         assert_eq!(model.disabled, Some(false));
-        assert_eq!(model.warn_threshold, Some(80.0));
-        assert_eq!(model.critical_threshold, Some(95.0));
     }
 
     #[test]

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -41,16 +41,31 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let symbol = bar_cfg.and_then(|c| c.symbol.as_deref());
     let style = bar_cfg.and_then(|c| c.style.as_deref());
 
-    // Format string takes priority if configured (AC1–4)
-    if let Some(fmt) = bar_cfg.and_then(|c| c.format.as_deref()) {
-        return crate::format::apply_module_format(fmt, Some(&bar_content), symbol, style);
-    }
-
-    // Default behavior — unchanged (AC5): threshold-style logic
+    // Extract threshold variables FIRST (before format check)
     let warn_threshold = bar_cfg.and_then(|c| c.warn_threshold);
     let warn_style = bar_cfg.and_then(|c| c.warn_style.as_deref());
     let critical_threshold = bar_cfg.and_then(|c| c.critical_threshold);
     let critical_style = bar_cfg.and_then(|c| c.critical_style.as_deref());
+
+    // Format string takes priority if configured (AC2)
+    if let Some(fmt) = bar_cfg.and_then(|c| c.format.as_deref()) {
+        let effective_style = crate::ansi::resolve_threshold_style(
+            Some(used_pct),
+            style,
+            warn_threshold,
+            warn_style,
+            critical_threshold,
+            critical_style,
+        );
+        return crate::format::apply_module_format(
+            fmt,
+            Some(&bar_content),
+            symbol,
+            effective_style,
+        );
+    }
+
+    // Default behavior — unchanged (AC5): threshold-style logic
 
     Some(crate::ansi::apply_style_with_threshold(
         &bar_content,
@@ -223,5 +238,105 @@ mod tests {
             "expected no filled chars at 0%: {result:?}"
         );
         assert!(result.contains("0%"));
+    }
+
+    #[test]
+    fn test_context_bar_format_below_threshold_uses_base_style() {
+        // AC2: format + value below all thresholds → base style (None) used
+        let ctx = ctx_with_pct(50.0); // below warn_threshold of 70.0
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(85.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            !result.contains('\x1b'),
+            "expected NO ANSI codes below threshold with no base style: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_format_with_warn_threshold_uses_warn_style() {
+        // AC2: format + warn_threshold → warn_style flows into format renderer
+        let ctx = ctx_with_pct(75.0); // above warn_threshold of 70.0
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(85.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for warn style: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_format_with_critical_threshold_uses_critical_style() {
+        // AC2: format + critical_threshold → critical_style flows into format renderer
+        let ctx = ctx_with_pct(90.0); // above critical_threshold of 85.0
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(85.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for critical style: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_format_warn_and_critical_produce_different_styles() {
+        // M1 fix: verify warn and critical styles are distinguishable
+        let warn_cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(100.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let crit_cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(70.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(70.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let ctx = ctx_with_pct(75.0);
+        let warn_result = render(&ctx, &warn_cfg).unwrap();
+        let crit_result = render(&ctx, &crit_cfg).unwrap();
+        assert_ne!(
+            warn_result, crit_result,
+            "warn and critical styles must produce different output"
+        );
     }
 }

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -31,18 +31,28 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let style = cost_cfg.and_then(|c| c.style.as_deref());
     let formatted = format!("${:.2}", val);
 
-    // Format string takes priority if configured (AC1–4)
+    // Extract threshold variables FIRST (before format check)
+    let warn_threshold = cost_cfg.and_then(|c| c.warn_threshold);
+    let warn_style = cost_cfg.and_then(|c| c.warn_style.as_deref());
+    let critical_threshold = cost_cfg.and_then(|c| c.critical_threshold);
+    let critical_style = cost_cfg.and_then(|c| c.critical_style.as_deref());
+
+    // Format string takes priority if configured (AC1)
     if let Some(fmt) = cost_cfg.and_then(|c| c.format.as_deref()) {
-        return crate::format::apply_module_format(fmt, Some(&formatted), symbol, style);
+        let effective_style = crate::ansi::resolve_threshold_style(
+            Some(val),
+            style,
+            warn_threshold,
+            warn_style,
+            critical_threshold,
+            critical_style,
+        );
+        return crate::format::apply_module_format(fmt, Some(&formatted), symbol, effective_style);
     }
 
     // Default behavior — unchanged (AC5): threshold-style logic
     let symbol_str = symbol.unwrap_or("");
     let content = format!("{symbol_str}{formatted}");
-    let warn_threshold = cost_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = cost_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = cost_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = cost_cfg.and_then(|c| c.critical_style.as_deref());
 
     Some(crate::ansi::apply_style_with_threshold(
         &content,
@@ -345,5 +355,117 @@ mod tests {
         let ctx = ctx_with_cost(0.01);
         let result = render_total_lines_removed(&ctx, &CshipConfig::default());
         assert_eq!(result, Some("23".to_string()));
+    }
+
+    #[test]
+    fn test_cost_format_below_threshold_uses_base_style() {
+        // AC1: format + value below all thresholds → base style (None) used
+        let ctx = ctx_with_cost(3.0); // below warn_threshold of 5.0
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            !result.contains('\x1b'),
+            "expected NO ANSI codes below threshold with no base style: {result:?}"
+        );
+        assert!(
+            result.contains("$3.00"),
+            "expected formatted value: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cost_format_with_warn_threshold_uses_warn_style() {
+        // AC1: format + warn_threshold → warn_style flows into format renderer
+        let ctx = ctx_with_cost(6.0); // above warn_threshold of 5.0
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for warn style: {result:?}"
+        );
+        assert!(
+            result.contains("$6.00"),
+            "expected formatted value: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cost_format_with_critical_threshold_uses_critical_style() {
+        // AC1: format + critical_threshold → critical_style flows into format renderer
+        let ctx = ctx_with_cost(12.0); // above critical_threshold of 10.0
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(10.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for critical style: {result:?}"
+        );
+        assert!(
+            result.contains("$12.00"),
+            "expected formatted value: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cost_format_warn_and_critical_produce_different_styles() {
+        // M1 fix: verify warn and critical styles are distinguishable
+        let warn_cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(100.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let crit_cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                warn_threshold: Some(5.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(5.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let ctx = ctx_with_cost(6.0);
+        let warn_result = render(&ctx, &warn_cfg).unwrap();
+        let crit_result = render(&ctx, &crit_cfg).unwrap();
+        assert_ne!(
+            warn_result, crit_result,
+            "warn and critical styles must produce different output"
+        );
     }
 }

--- a/tests/fixtures/sample_starship.toml
+++ b/tests/fixtures/sample_starship.toml
@@ -16,5 +16,3 @@ style = "bold green"
 symbol = ""
 disabled = false
 label = false
-warn_threshold = 80.0
-critical_threshold = 95.0


### PR DESCRIPTION
## Summary

- Adds `resolve_threshold_style` to `ansi.rs` to resolve effective warn/critical style from numeric thresholds without painting content — used when a format string is configured
- Updates `cost` and `context_bar` modules to call `resolve_threshold_style` before delegating to `apply_module_format`, so threshold escalation works with custom format strings
- Removes erroneous `warn_threshold`/`critical_threshold` fields from `ModelConfig` (they only belong on threshold-aware modules) and cleans up the test fixture accordingly

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (includes 6 new unit tests for `resolve_threshold_style` and 4 new integration tests each for `cost` and `context_bar`)
- [x] Verify `context_bar` with a format string escalates to `warn_style` when usage ≥ `warn_threshold`
- [x] Verify `cost` with a format string escalates to `critical_style` when cost ≥ `critical_threshold`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)