### PR TITLE
Add Starship module passthrough — Closes #19 (Story 4.1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod context;
 pub mod explain;
 pub mod format;
 pub mod modules;
+pub mod passthrough;
 pub mod renderer;

--- a/src/passthrough.rs
+++ b/src/passthrough.rs
@@ -1,0 +1,95 @@
+//! Starship passthrough module renderer.
+//!
+//! Invokes `starship module <name>` as a subprocess and returns captured stdout.
+//! Story 4.1: subprocess only, no cache. Story 4.2 adds `cache.rs` with 5s TTL.
+
+use std::process::{Command, Stdio};
+
+/// Render a Starship passthrough module by invoking `starship module <name>`.
+///
+/// - Returns `None` silently if `starship` binary is not found (FR30 minimal install path).
+/// - Returns `None` with `tracing::warn!` if the subprocess exits non-zero.
+/// - Returns `None` if stdout is empty (Starship convention: module has nothing to show).
+/// - Changes working directory to `workspace.current_dir` before invocation (AC2).
+pub fn render_passthrough(name: &str, ctx: &crate::context::Context) -> Option<String> {
+    let cwd = ctx
+        .workspace
+        .as_ref()
+        .and_then(|w| w.current_dir.as_deref());
+
+    let mut cmd = Command::new("starship");
+    cmd.args(["module", name]);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::null());
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(_) => return None, // starship not found — silent (FR30)
+    };
+
+    if !output.status.success() {
+        tracing::warn!("passthrough: `starship module {name}` exited with non-zero status");
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim_end_matches(&['\r', '\n'][..]);
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::Context;
+
+    #[test]
+    fn test_render_passthrough_returns_none_for_nonexistent_module() {
+        // starship exits non-zero for unknown module names → None
+        let result = render_passthrough("__cship_nonexistent_xyz__", &Context::default());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_render_passthrough_returns_none_on_nonzero_exit() {
+        // Create a fake starship script that exits non-zero to exercise the warn path (AC4).
+        // Real starship exits 0 even for unknown modules, so we need a mock.
+        use std::fs;
+        #[cfg(unix)]
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join("cship_test_nonzero");
+        fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("starship");
+        fs::write(&script, "#!/bin/sh\nexit 1\n").unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let original = std::env::var("PATH").unwrap_or_default();
+        unsafe { std::env::set_var("PATH", dir.to_str().unwrap()) };
+        let result = render_passthrough("directory", &Context::default());
+        unsafe { std::env::set_var("PATH", &original) };
+        let _ = fs::remove_dir_all(&dir);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_render_passthrough_returns_none_silently_when_starship_missing() {
+        // Override PATH so starship binary cannot be found, exercising the Err(_) → None path (AC5).
+        // SAFETY: No other unit tests in this module depend on PATH; integration tests run in a
+        // separate process. set_var is unsafe in edition 2024 due to process-global mutation.
+        let original = std::env::var("PATH").unwrap_or_default();
+        unsafe { std::env::set_var("PATH", "/nonexistent_cship_test_dir") };
+        let result = render_passthrough("directory", &Context::default());
+        unsafe { std::env::set_var("PATH", &original) };
+        assert!(result.is_none());
+    }
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -56,9 +56,9 @@ fn render_line(line: &str, ctx: &Context, cfg: &CshipConfig) -> String {
                 }
             }
             Token::Passthrough(name) => {
-                tracing::debug!(
-                    "cship: passthrough module '{name}' not yet implemented — skipping"
-                );
+                if let Some(rendered) = crate::passthrough::render_passthrough(&name, ctx) {
+                    parts.push(rendered);
+                }
             }
             Token::Literal(text) => {
                 parts.push(text);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -180,8 +180,11 @@ fn test_two_row_layout_produces_newline_separated_output() {
 
 #[test]
 fn test_passthrough_tokens_skipped_silently() {
-    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
-    // passthrough_only.toml: lines = ["$git_branch"] → Story 1.4 returns None → empty stdout
+    // Use inline JSON with a guaranteed-nonexistent workspace path so that
+    // starship subprocess spawn fails silently (no WARN) regardless of whether
+    // starship is installed on the test machine.
+    let json = r#"{"session_id":"test","cwd":"/tmp","transcript_path":"/tmp/t.jsonl","version":"1.0","exceeds_200k_tokens":false,"model":{"id":"test","display_name":"Test"},"workspace":{"current_dir":"/nonexistent_cship_test_path_12345","project_dir":"/tmp"},"output_style":{"name":"default"},"cost":{"total_cost_usd":0.0}}"#;
+    // passthrough_only.toml: lines = ["$git_branch"] → None → empty stdout
     cship()
         .args(["--config", "tests/fixtures/passthrough_only.toml"])
         .env("RUST_LOG", "debug")
@@ -189,7 +192,6 @@ fn test_passthrough_tokens_skipped_silently() {
         .assert()
         .success()
         .stdout("")
-        // Passthrough logs at debug level — no error or warn level output
         .stderr(predicate::str::contains("error").not())
         .stderr(predicate::str::contains("WARN").not());
 }
@@ -785,6 +787,50 @@ fn test_explain_shows_warning_for_disabled_module() {
         stdout.contains("[cship.model]"),
         "expected specific section '[cship.model]' in remediation hint: {stdout}"
     );
+}
+
+// ── Story 4.1: Starship passthrough integration tests ─────────────────────
+
+fn starship_available() -> bool {
+    std::process::Command::new("starship")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_passthrough_directory_renders_when_starship_installed() {
+    if !starship_available() {
+        return; // skip silently in environments without starship
+    }
+    // Use a real workspace.current_dir (/tmp) so starship can spawn correctly (AC2).
+    let json = r#"{"session_id":"test","cwd":"/tmp","transcript_path":"/tmp/t.jsonl","version":"1.0","exceeds_200k_tokens":false,"model":{"id":"claude-opus-4-6","display_name":"Opus"},"workspace":{"current_dir":"/tmp","project_dir":"/tmp"},"output_style":{"name":"default"},"cost":{"total_cost_usd":0.0}}"#;
+    let output = cship()
+        .args(["--config", "tests/fixtures/passthrough_directory.toml"])
+        .write_stdin(json)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "expected non-empty output from $directory passthrough: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_native_renders_alongside_passthrough_not_installed() {
+    // sample_starship.toml: lines = ["$cship.model $git_branch", "$cship.cost"]
+    // Native $cship.model renders "Opus" regardless of whether starship is present.
+    // Passthrough $git_branch renders via starship (or None silently). No panic, exit 0.
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/sample_starship.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Opus"));
 }
 
 // ── Story 2.5: Per-module format strings integration tests ────────────────

--- a/tests/fixtures/passthrough_directory.toml
+++ b/tests/fixtures/passthrough_directory.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$directory"]


### PR DESCRIPTION
## Summary

- Implements `src/passthrough.rs` which spawns `starship module <name>` as a subprocess and captures its stdout
- `renderer.rs` now calls `passthrough::render_passthrough` for `Token::Passthrough` segments instead of silently skipping them
- Falls back to `None` silently when starship is not installed, not on PATH, or returns a non-zero exit code
- Adds `tests/fixtures/passthrough_directory.toml` and two new integration tests (one skipped when starship absent)

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 62/62 pass (including `test_passthrough_directory_renders_when_starship_installed` which skips gracefully on machines without starship)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)