### PR TITLE
Story 6.1: Release Pipeline Closes #24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
 
   release:
     name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow (`.github/workflows/release.yml`)
- Triggered on `v*` tags and `workflow_dispatch`
- Runs test matrix (Ubuntu + macOS), then builds release binaries for 4 targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`
- Publishes binaries as a GitHub Release via `softprops/action-gh-release`

## Test plan
- [x] Push a `v*` tag and verify the workflow triggers
- [x] Confirm all 4 build targets produce valid binaries
- [x] Confirm GitHub Release is created with all artifacts attached

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)