### PR TITLE
Story 7.3: cship.toml as Dedicated Config File (#53)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,7 +196,11 @@ pub fn load_with_source(
         });
         return ConfigLoadResult {
             config,
-            source: ConfigSource::Override(path.to_path_buf()),
+            source: if path.file_name().map(|n| n == "cship.toml").unwrap_or(false) {
+                ConfigSource::DedicatedFile(path.to_path_buf())
+            } else {
+                ConfigSource::Override(path.to_path_buf())
+            },
         };
     }
 
@@ -559,6 +563,24 @@ mod tests {
         assert!(
             matches!(result.source, ConfigSource::DedicatedFile(_)),
             "expected DedicatedFile source, got: {}",
+            result.source
+        );
+        assert_eq!(result.config.lines.as_ref().unwrap()[0], "$cship.cost");
+    }
+
+    #[test]
+    fn test_load_with_source_override_cship_toml_returns_dedicated_file_variant() {
+        // Regression: --config override pointing to cship.toml must return DedicatedFile, not Override
+        let dir = tempfile::tempdir().unwrap();
+
+        let cship_path = dir.path().join("cship.toml");
+        let mut f = std::fs::File::create(&cship_path).unwrap();
+        writeln!(f, "lines = [\"$cship.cost\"]").unwrap();
+
+        let result = load_with_source(Some(&cship_path), None);
+        assert!(
+            matches!(result.source, ConfigSource::DedicatedFile(_)),
+            "expected DedicatedFile source for cship.toml override, got: {}",
             result.source
         );
         assert_eq!(result.config.lines.as_ref().unwrap()[0], "$cship.cost");


### PR DESCRIPTION
## Summary

- Adds `ConfigSource::DedicatedFile` variant for `cship.toml` paths
- `cship.toml` is checked before `starship.toml` at each discovery level (workspace walk-up and `~/.config/`)
- `cship.toml` is parsed directly as `CshipConfig` — no `[cship]` wrapper needed
- Lenient handling: if `cship.toml` accidentally contains `[cship]`, emits `tracing::warn!` and falls back to wrapper extraction (AC#7)
- `--config` override routes to `load_cship_toml` when filename is `cship.toml`
- `cship explain` correctly displays `cship.toml` path with `(cship.toml)` annotation
- All existing tests pass; 7 new tests cover AC#1–7 and the new `DedicatedFile` source variant

## Test plan

- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `test_cship_toml_takes_priority_over_starship_toml` — AC#1
- [x] `test_cship_toml_absent_falls_through_to_starship_toml` — AC#2 (backwards compat)
- [x] `test_cship_toml_walk_up_from_subdirectory` — AC#4
- [x] `test_cship_toml_with_wrapper_section_still_parses` — AC#7 (lenient handling)
- [x] `test_cship_toml_direct_cshipconfig_parsing` — AC#1 (direct parse)
- [x] `test_dedicated_file_config_source_display` — AC#6 (explain display)
- [x] `test_override_cship_toml_routes_correctly` — AC#5 (--config flag)
- [x] `test_load_with_source_returns_dedicated_file_variant` — M1 (source variant)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)