### PR TITLE
feat(#71): add manual release trigger with version input and tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "ERROR: Version must match vX.Y.Z format (e.g. v1.2.3)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger with a required `version` input (e.g. `v1.2.3`) for manual releases
- Adds a `tag` job that validates the version format, checks the tag doesn't already exist, then creates and pushes the git tag
- Adds a `concurrency` group (`release`) to prevent overlapping release runs
- Updates `test` and `release` jobs to depend on `tag` (skipped safely on push-triggered runs)
- Passes `tag_name` explicitly to `softprops/action-gh-release` to support both push-triggered and manually-triggered releases

## Test plan

- [ ] Trigger workflow manually via GitHub Actions UI with a valid version (e.g. `v0.1.1`) and verify tag is created and release is published
- [ ] Trigger with an invalid version format (e.g. `1.2.3`) and verify it fails at validation step
- [ ] Trigger with an existing tag and verify it fails at the duplicate-tag check
- [ ] Push a new tag directly (e.g. `git push origin vX.Y.Z`) and verify the `tag` job is skipped but `test` and `release` still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #71