### PR TITLE
#72 Story 8-2: Publish to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,3 +122,21 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           files: cship-*/cship-*
+
+  publish:
+    name: Publish to crates.io
+    needs: release
+    if: "!cancelled() && needs.release.result == 'success'"
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version || github.ref_name }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://cship.dev"
 keywords      = ["starship", "claude", "statusline", "terminal"]
 categories    = ["command-line-utilities"]
 readme        = "README.md"
+exclude       = [".github/"]
 
 [dependencies]
 clap               = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# cship
+
+Beautiful, Blazing-fast, Customizable Claude Code Statusline.
+
+## Install
+
+### From crates.io
+
+```sh
+cargo install cship
+```
+
+### From source
+
+```sh
+git clone https://github.com/stephenleo/cship
+cd cship
+cargo install --path .
+```
+
+## Usage
+
+Add to your shell configuration to display a customizable statusline for Claude Code sessions.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
## Summary

- Adds a `publish` job to the release workflow that automatically publishes to crates.io after a successful release
- Excludes `.github/` from the published crate package via `Cargo.toml`
- Adds `README.md` to the repo (required for crates.io listing)

## Test plan

- [ ] Verify the `publish` job appears in the release workflow and depends on `release` job success
- [x] Confirm `CARGO_REGISTRY_TOKEN` secret is set in repo settings
- [ ] Trigger a release and confirm the crate is published to crates.io
- [ ] Verify `cargo install cship` installs the latest version successfully

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)