### PR TITLE
release: v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cship"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name          = "cship"
-version       = "1.0.0"
+version       = "1.1.0"
+authors       = ["Marie Stephen Leo"]
 edition       = "2024"
 description   = "Beautiful, Blazing-fast, Customizable Claude Code Statusline"
 license       = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version to 1.1.0
- Add `authors` field to Cargo.toml (`Marie Stephen Leo`)

## Test plan
- [x] `cargo publish --dry-run` passes (already verified locally)
- [ ] Manually trigger GH Actions to publish to crates.io

Closes #