### PR TITLE
feat: add configurable TTL for usage_limits cache

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -148,10 +148,10 @@ pub fn read_usage_limits(transcript_path: &Path, allow_stale: bool) -> Option<Us
 }
 
 /// Write usage limits data to the cache file.
-/// Sets `expires_at` to now + 60 seconds.
+/// Sets `expires_at` to now + `ttl_secs` seconds (default 60).
 /// Silently no-ops on any I/O error — cache write failure must never surface to the user.
 /// The OAuth token is never present in the written data (NFR-S3).
-pub fn write_usage_limits(transcript_path: &Path, data: &UsageLimitsData) {
+pub fn write_usage_limits(transcript_path: &Path, data: &UsageLimitsData, ttl_secs: u64) {
     let Some(path) = usage_limits_cache_path(transcript_path) else {
         return;
     };
@@ -161,7 +161,7 @@ pub fn write_usage_limits(transcript_path: &Path, data: &UsageLimitsData) {
     let now = now_epoch();
     let envelope = UsageLimitsCacheEnvelope {
         data: data.clone(),
-        expires_at: now + 60,
+        expires_at: now + ttl_secs,
         five_hour_resets_at: epoch_or_never(&data.five_hour_resets_at),
         seven_day_resets_at: epoch_or_never(&data.seven_day_resets_at),
     };
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn test_usage_limits_cache_hit_within_ttl() {
         let (dir, transcript) = temp_transcript("s5_2_hit");
-        write_usage_limits(&transcript, &sample_data());
+        write_usage_limits(&transcript, &sample_data(), 60);
         let result = read_usage_limits(&transcript, false);
         assert!(result.is_some(), "fresh cache should return Some");
         let data = result.unwrap();
@@ -316,7 +316,7 @@ mod tests {
     fn test_usage_limits_cache_file_path_and_json_structure() {
         let dir = tempfile::tempdir().expect("tempdir");
         let transcript = dir.path().join("transcript.jsonl");
-        write_usage_limits(&transcript, &sample_data());
+        write_usage_limits(&transcript, &sample_data(), 60);
         let expected_path = dir.path().join("cship").join("transcript-usage-limits");
         assert!(expected_path.exists(), "cache file at: {expected_path:?}");
         let raw = std::fs::read_to_string(&expected_path).unwrap();
@@ -334,7 +334,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let transcript = dir.path().join("transcript.jsonl");
         // Write a valid cache entry first
-        write_usage_limits(&transcript, &sample_data());
+        write_usage_limits(&transcript, &sample_data(), 60);
         // Overwrite with an expired envelope (expires_at = 0, resets_at far future)
         let path = dir.path().join("cship").join("transcript-usage-limits");
         let expired = serde_json::json!({
@@ -365,7 +365,7 @@ mod tests {
             five_hour_resets_at: "2000-01-01T00:00:00Z".into(), // past
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(), // future
         };
-        write_usage_limits(&transcript, &data);
+        write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
         assert!(
             result.is_none(),
@@ -378,7 +378,7 @@ mod tests {
     fn test_usage_limits_write_creates_directory() {
         let dir = tempfile::tempdir().expect("tempdir");
         let transcript = dir.path().join("deep").join("nested").join("t.jsonl");
-        write_usage_limits(&transcript, &sample_data());
+        write_usage_limits(&transcript, &sample_data(), 60);
         let cache_file = dir
             .path()
             .join("deep")
@@ -403,7 +403,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(), // future
             seven_day_resets_at: "2000-01-01T00:00:00Z".into(), // past
         };
-        write_usage_limits(&transcript, &data);
+        write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
         assert!(
             result.is_none(),
@@ -423,7 +423,7 @@ mod tests {
             five_hour_resets_at: String::new(),
             seven_day_resets_at: String::new(),
         };
-        write_usage_limits(&transcript, &data);
+        write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
         assert!(
             result.is_some(),
@@ -437,7 +437,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let transcript = dir.path().join("transcript.jsonl");
         // Write a valid cache entry, then overwrite with expired TTL
-        write_usage_limits(&transcript, &sample_data());
+        write_usage_limits(&transcript, &sample_data(), 60);
         let path = dir.path().join("cship").join("transcript-usage-limits");
         let expired = serde_json::json!({
             "data": {
@@ -508,7 +508,7 @@ mod tests {
             five_hour_resets_at: "2000-01-01T00:00:00+00:00".into(), // past, +00:00 format
             seven_day_resets_at: "2099-01-01T00:00:00+00:00".into(), // future
         };
-        write_usage_limits(&transcript, &data);
+        write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
         assert!(
             result.is_none(),
@@ -530,5 +530,28 @@ mod tests {
             Some(946_684_801),
             "fractional seconds are truncated, not rounded"
         );
+    }
+
+    #[test]
+    fn test_usage_limits_custom_ttl_sets_expires_at() {
+        // Issue #95: configurable TTL — verify custom TTL is respected in cache envelope
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = dir.path().join("transcript.jsonl");
+        write_usage_limits(&transcript, &sample_data(), 300);
+        let path = dir.path().join("cship").join("transcript-usage-limits");
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let expires_at = v["expires_at"].as_u64().unwrap();
+        let now = now_epoch();
+        // expires_at should be approximately now + 300 (±2s tolerance for test execution)
+        assert!(
+            expires_at >= now + 298 && expires_at <= now + 302,
+            "expected expires_at ~now+300, got delta={}",
+            expires_at.saturating_sub(now)
+        );
+        // Cache should still be valid (not expired within the custom window)
+        let result = read_usage_limits(&transcript, false);
+        assert!(result.is_some(), "cache with 300s TTL should be valid");
+        drop(dir);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,9 @@ pub struct UsageLimitsConfig {
     pub warn_style: Option<String>,
     pub critical_threshold: Option<f64>,
     pub critical_style: Option<String>,
+    /// Cache refresh interval in seconds. Default: 60.
+    /// Increase to reduce API pressure with many concurrent sessions.
+    pub ttl: Option<u64>,
     /// Reserved — not yet rendered. Use `five_hour_format`, `seven_day_format`,
     /// and `separator` for per-section format control.
     pub format: Option<String>,

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -48,10 +48,13 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         };
 
         // Step 4b: dispatch fetch with 2s timeout
+        // Configurable TTL (default 60s) — Issue #95
+        let ttl_secs = ul_cfg.and_then(|c| c.ttl).unwrap_or(60);
+
         match fetch_with_timeout(move || crate::usage_limits::fetch_usage_limits(&token)) {
             Some(fresh) => {
                 // Step 4c: write fresh data to cache for future renders
-                cache::write_usage_limits(transcript_path, &fresh);
+                cache::write_usage_limits(transcript_path, &fresh, ttl_secs);
                 fresh
             }
             // AC #4: on timeout or API error, fall back to last cached value (may be stale)
@@ -250,7 +253,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
             transcript_path: Some(transcript.to_str().unwrap().to_string()),
@@ -273,7 +276,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
             transcript_path: Some(transcript.to_str().unwrap().to_string()),
@@ -304,7 +307,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
             transcript_path: Some(transcript.to_str().unwrap().to_string()),
@@ -340,7 +343,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
             transcript_path: Some(transcript.to_str().unwrap().to_string()),
@@ -376,7 +379,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
         // Verify read_usage_limits(allow_stale=true) works even after TTL would normally expire
         let stale = crate::cache::read_usage_limits(&transcript, true);
         assert!(
@@ -602,7 +605,7 @@ mod tests {
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
         };
-        crate::cache::write_usage_limits(&transcript, &data);
+        crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
             transcript_path: Some(transcript.to_str().unwrap().to_string()),


### PR DESCRIPTION
## Summary

Closes #95

- Adds `ttl` field to `[cship.usage_limits]` config (default: 60s, backward compatible)
- Threads configured TTL from config → module render → cache write
- Only 3 files changed: `config.rs`, `cache.rs`, `modules/usage_limits.rs`

### Usage

```toml
[cship.usage_limits]
ttl = 300  # cache refresh interval in seconds (default: 60)
```

## Test plan

- [x] `cargo check` compiles cleanly
- [x] `cargo test` — all existing tests pass (updated to pass default TTL)
- [x] New test `test_usage_limits_custom_ttl_sets_expires_at` verifies custom TTL is written to cache envelope
- [x] Manual: set `ttl = 300` in config, verify cache file `expires_at` is ~300s in the future

🤖 Generated with [Claude Code](https://claude.com/claude-code)