### PR TITLE
refactor: Reduce sub-field render boilerplate

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,34 +48,18 @@ pub struct CostConfig {
     pub critical_style: Option<String>,
     pub format: Option<String>,
     // Sub-field per-display configs (map to [cship.cost.total_cost_usd] etc.)
-    pub total_cost_usd: Option<CostSubfieldConfig>,
-    pub total_duration_ms: Option<CostSubfieldConfig>,
-    pub total_api_duration_ms: Option<CostSubfieldConfig>,
-    pub total_lines_added: Option<CostSubfieldConfig>,
-    pub total_lines_removed: Option<CostSubfieldConfig>,
+    pub total_cost_usd: Option<SubfieldConfig>,
+    pub total_duration_ms: Option<SubfieldConfig>,
+    pub total_api_duration_ms: Option<SubfieldConfig>,
+    pub total_lines_added: Option<SubfieldConfig>,
+    pub total_lines_removed: Option<SubfieldConfig>,
 }
 
-/// Configuration for individual `[cship.cost.*]` sub-field modules.
+/// Unified configuration for individual sub-field modules
+/// (e.g. `[cship.cost.total_cost_usd]`, `[cship.context_window.used_percentage]`).
 #[derive(Debug, Deserialize, Default)]
-pub struct CostSubfieldConfig {
+pub struct SubfieldConfig {
     pub style: Option<String>,
-    /// Reserved — not yet rendered; included for config schema consistency.
-    pub symbol: Option<String>,
-    pub disabled: Option<bool>,
-    /// Reserved — not yet rendered; included for config schema consistency.
-    pub label: Option<String>,
-    pub warn_threshold: Option<f64>,
-    pub warn_style: Option<String>,
-    pub critical_threshold: Option<f64>,
-    pub critical_style: Option<String>,
-    pub format: Option<String>,
-}
-
-/// Configuration for individual `[cship.context_window.*]` sub-field modules.
-#[derive(Debug, Deserialize, Default)]
-pub struct ContextWindowSubfieldConfig {
-    pub style: Option<String>,
-    /// Used only in the format path (via `$symbol`); ignored in the default render path.
     pub symbol: Option<String>,
     pub disabled: Option<bool>,
     pub warn_threshold: Option<f64>,
@@ -87,6 +71,82 @@ pub struct ContextWindowSubfieldConfig {
     /// Use for decreasing-health indicators like `remaining_percentage` (low = bad).
     /// When set, parent-level thresholds are NOT inherited (they are in the non-inverted domain).
     pub invert_threshold: Option<bool>,
+}
+
+/// Backwards-compatible type aliases (used by test code).
+#[cfg(test)]
+pub type CostSubfieldConfig = SubfieldConfig;
+#[cfg(test)]
+pub type ContextWindowSubfieldConfig = SubfieldConfig;
+
+/// Trait for uniform access to style/threshold fields shared by config types.
+/// Used by `render_styled_value()` to resolve sub-field → parent fallback.
+///
+/// `format_str()` and `symbol_str()` default to `None`. Only parent configs
+/// whose sub-fields should inherit format/symbol (i.e., `ContextWindowConfig`)
+/// override these.
+pub trait HasThresholdStyle {
+    fn style(&self) -> Option<&str>;
+    fn warn_threshold(&self) -> Option<f64>;
+    fn warn_style(&self) -> Option<&str>;
+    fn critical_threshold(&self) -> Option<f64>;
+    fn critical_style(&self) -> Option<&str>;
+    fn format_str(&self) -> Option<&str> {
+        None
+    }
+    fn symbol_str(&self) -> Option<&str> {
+        None
+    }
+}
+
+macro_rules! impl_has_threshold_style {
+    ($t:ty) => {
+        impl HasThresholdStyle for $t {
+            fn style(&self) -> Option<&str> {
+                self.style.as_deref()
+            }
+            fn warn_threshold(&self) -> Option<f64> {
+                self.warn_threshold
+            }
+            fn warn_style(&self) -> Option<&str> {
+                self.warn_style.as_deref()
+            }
+            fn critical_threshold(&self) -> Option<f64> {
+                self.critical_threshold
+            }
+            fn critical_style(&self) -> Option<&str> {
+                self.critical_style.as_deref()
+            }
+        }
+    };
+}
+
+impl_has_threshold_style!(CostConfig);
+impl_has_threshold_style!(ContextBarConfig);
+impl_has_threshold_style!(UsageLimitsConfig);
+
+impl HasThresholdStyle for ContextWindowConfig {
+    fn style(&self) -> Option<&str> {
+        self.style.as_deref()
+    }
+    fn warn_threshold(&self) -> Option<f64> {
+        self.warn_threshold
+    }
+    fn warn_style(&self) -> Option<&str> {
+        self.warn_style.as_deref()
+    }
+    fn critical_threshold(&self) -> Option<f64> {
+        self.critical_threshold
+    }
+    fn critical_style(&self) -> Option<&str> {
+        self.critical_style.as_deref()
+    }
+    fn format_str(&self) -> Option<&str> {
+        self.format.as_deref()
+    }
+    fn symbol_str(&self) -> Option<&str> {
+        self.symbol.as_deref()
+    }
 }
 
 /// Configuration for `[cship.context_bar]` — visual progress bar with thresholds.
@@ -119,15 +179,15 @@ pub struct ContextWindowConfig {
     pub critical_style: Option<String>,
     pub format: Option<String>,
     // Per-sub-field configs (map to [cship.context_window.used_percentage] etc.)
-    pub used_percentage: Option<ContextWindowSubfieldConfig>,
-    pub remaining_percentage: Option<ContextWindowSubfieldConfig>,
-    pub size: Option<ContextWindowSubfieldConfig>,
-    pub total_input_tokens: Option<ContextWindowSubfieldConfig>,
-    pub total_output_tokens: Option<ContextWindowSubfieldConfig>,
-    pub current_usage_input_tokens: Option<ContextWindowSubfieldConfig>,
-    pub current_usage_output_tokens: Option<ContextWindowSubfieldConfig>,
-    pub current_usage_cache_creation_input_tokens: Option<ContextWindowSubfieldConfig>,
-    pub current_usage_cache_read_input_tokens: Option<ContextWindowSubfieldConfig>,
+    pub used_percentage: Option<SubfieldConfig>,
+    pub remaining_percentage: Option<SubfieldConfig>,
+    pub size: Option<SubfieldConfig>,
+    pub total_input_tokens: Option<SubfieldConfig>,
+    pub total_output_tokens: Option<SubfieldConfig>,
+    pub current_usage_input_tokens: Option<SubfieldConfig>,
+    pub current_usage_output_tokens: Option<SubfieldConfig>,
+    pub current_usage_cache_creation_input_tokens: Option<SubfieldConfig>,
+    pub current_usage_cache_read_input_tokens: Option<SubfieldConfig>,
 }
 
 /// Configuration for `[cship.vim]` — vim mode display.

--- a/src/format.rs
+++ b/src/format.rs
@@ -10,6 +10,76 @@
 //!
 //! [Source: architecture.md#Core Architectural Decisions, epics.md#Story 2.5]
 
+/// Centralized style/threshold/format rendering for sub-field render functions.
+///
+/// Resolves style, thresholds, and format strings using sub-field → parent fallback,
+/// handling `invert_threshold` for decreasing-health indicators (e.g. remaining_percentage).
+///
+/// # Arguments
+/// - `val_str`: Already-formatted display string (e.g. `"85"`, `"0.0123"`)
+/// - `threshold_val`: Numeric value for threshold comparison; `None` for non-threshold fields
+/// - `sub_cfg`: The sub-field's own `SubfieldConfig` (may be `None`)
+/// - `parent`: Parent config implementing `HasThresholdStyle` for fallback (may be `None`)
+///
+/// # Returns
+/// `None` when the format path renders empty (conditional group with absent `$value`).
+/// `Some(styled_string)` otherwise.
+pub fn render_styled_value(
+    val_str: &str,
+    threshold_val: Option<f64>,
+    sub_cfg: Option<&crate::config::SubfieldConfig>,
+    parent: Option<&dyn crate::config::HasThresholdStyle>,
+) -> Option<String> {
+    // Resolve all fields with sub → parent fallback
+    let style = sub_cfg
+        .and_then(|c| c.style.as_deref())
+        .or_else(|| parent.and_then(|p| p.style()));
+    let mut effective_val = threshold_val;
+    let mut warn_threshold = sub_cfg
+        .and_then(|c| c.warn_threshold)
+        .or_else(|| parent.and_then(|p| p.warn_threshold()));
+    let mut warn_style = sub_cfg
+        .and_then(|c| c.warn_style.as_deref())
+        .or_else(|| parent.and_then(|p| p.warn_style()));
+    let mut critical_threshold = sub_cfg
+        .and_then(|c| c.critical_threshold)
+        .or_else(|| parent.and_then(|p| p.critical_threshold()));
+    let mut critical_style = sub_cfg
+        .and_then(|c| c.critical_style.as_deref())
+        .or_else(|| parent.and_then(|p| p.critical_style()));
+
+    // Inverted thresholds: use sub-only values (negated) and negate the comparison value.
+    // Parent thresholds are in the non-inverted domain and must not be inherited.
+    if sub_cfg.and_then(|c| c.invert_threshold).unwrap_or(false) {
+        effective_val = threshold_val.map(|v| -v);
+        warn_threshold = sub_cfg.and_then(|c| c.warn_threshold).map(|t| -t);
+        warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
+        critical_threshold = sub_cfg.and_then(|c| c.critical_threshold).map(|t| -t);
+        critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
+    }
+
+    // Format path: resolve symbol, threshold style, then apply format
+    let fmt = sub_cfg
+        .and_then(|c| c.format.as_deref())
+        .or_else(|| parent.and_then(|p| p.format_str()));
+    if let Some(fmt) = fmt {
+        let symbol = sub_cfg
+            .and_then(|c| c.symbol.as_deref())
+            .or_else(|| parent.and_then(|p| p.symbol_str()));
+        let effective_style = crate::ansi::resolve_threshold_style(
+            effective_val, style, warn_threshold, warn_style,
+            critical_threshold, critical_style,
+        );
+        return apply_module_format(fmt, Some(val_str), symbol, effective_style);
+    }
+
+    // Default path: apply_style_with_threshold handles no-threshold gracefully
+    Some(crate::ansi::apply_style_with_threshold(
+        val_str, effective_val, style, warn_threshold, warn_style,
+        critical_threshold, critical_style,
+    ))
+}
+
 /// Apply a per-module format string.
 ///
 /// # Arguments
@@ -276,5 +346,98 @@ mod tests {
         assert!(s.contains("bar"), "value present: {s:?}");
         assert!(s.contains("🧠"), "symbol present: {s:?}");
         assert!(s.contains('\x1b'), "ANSI codes present: {s:?}");
+    }
+
+    // --- render_styled_value tests ---
+
+    #[test]
+    fn test_render_styled_value_with_format_string() {
+        // Format string present → returns formatted ANSI output
+        let sub = crate::config::SubfieldConfig {
+            format: Some("[$value]($style)".to_string()),
+            style: Some("bold green".to_string()),
+            ..Default::default()
+        };
+        let result = render_styled_value("85", Some(85.0), Some(&sub), None);
+        let s = result.unwrap();
+        assert!(s.contains("85"), "value present: {s:?}");
+        assert!(s.contains('\x1b'), "ANSI codes present: {s:?}");
+    }
+
+    #[test]
+    fn test_render_styled_value_no_format_threshold_above_warn() {
+        // No format, threshold above warn → returns threshold-styled output
+        let sub = crate::config::SubfieldConfig {
+            warn_threshold: Some(50.0),
+            warn_style: Some("yellow".to_string()),
+            critical_threshold: Some(90.0),
+            critical_style: Some("bold red".to_string()),
+            ..Default::default()
+        };
+        let result = render_styled_value("75", Some(75.0), Some(&sub), None);
+        let s = result.unwrap();
+        assert!(s.contains("75"), "value present: {s:?}");
+        assert!(s.contains('\x1b'), "ANSI codes for warn style: {s:?}");
+    }
+
+    #[test]
+    fn test_render_styled_value_no_format_no_threshold() {
+        // No format, no threshold → returns plain styled output
+        let sub = crate::config::SubfieldConfig {
+            style: Some("cyan".to_string()),
+            ..Default::default()
+        };
+        let result = render_styled_value("hello", None, Some(&sub), None);
+        let s = result.unwrap();
+        assert!(s.contains("hello"), "value present: {s:?}");
+        assert!(s.contains('\x1b'), "ANSI codes for base style: {s:?}");
+    }
+
+    #[test]
+    fn test_render_styled_value_invert_threshold() {
+        // invert_threshold: value 20 with warn_threshold 30 → inverted: -20 >= -30 → warn fires
+        let sub = crate::config::SubfieldConfig {
+            invert_threshold: Some(true),
+            warn_threshold: Some(30.0),
+            warn_style: Some("yellow".to_string()),
+            critical_threshold: Some(10.0),
+            critical_style: Some("bold red".to_string()),
+            ..Default::default()
+        };
+        let result = render_styled_value("20", Some(20.0), Some(&sub), None);
+        let s = result.unwrap();
+        assert!(s.contains("20"), "value present: {s:?}");
+        assert!(s.contains('\x1b'), "ANSI codes for inverted warn: {s:?}");
+    }
+
+    #[test]
+    fn test_render_styled_value_parent_fallback_style() {
+        // No sub_cfg style → uses parent style
+        let sub = crate::config::SubfieldConfig {
+            ..Default::default()
+        };
+        let parent = crate::config::ContextWindowConfig {
+            style: Some("bold magenta".to_string()),
+            ..Default::default()
+        };
+        let result = render_styled_value(
+            "42",
+            None,
+            Some(&sub),
+            Some(&parent as &dyn crate::config::HasThresholdStyle),
+        );
+        let s = result.unwrap();
+        assert!(s.contains("42"), "value present: {s:?}");
+        assert!(
+            s.contains('\x1b'),
+            "ANSI codes from parent style: {s:?}"
+        );
+    }
+
+    #[test]
+    fn test_render_styled_value_no_sub_no_parent() {
+        // No sub_cfg, no parent → returns plain val_str
+        let result = render_styled_value("plain", None, None, None);
+        assert_eq!(result, Some("plain".to_string()));
     }
 }

--- a/src/modules/context_window.rs
+++ b/src/modules/context_window.rs
@@ -39,47 +39,12 @@ pub fn render_used_percentage(ctx: &Context, cfg: &CshipConfig) -> Option<String
         }
     };
     let val_str = format!("{:.0}", val);
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.remaining_percentage` — integer percentage, no `%` sign.
@@ -104,60 +69,12 @@ pub fn render_remaining_percentage(ctx: &Context, cfg: &CshipConfig) -> Option<S
         }
     };
     let val_str = format!("{:.0}", val);
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let invert = sub_cfg.and_then(|c| c.invert_threshold).unwrap_or(false);
-    // When inverted, don't inherit parent thresholds — they live in the non-inverted domain.
-    // Negate both value and thresholds so `val >= thresh` becomes `val <= original_thresh`.
-    let (effective_val, warn_threshold, warn_style, critical_threshold, critical_style) = if invert
-    {
-        let w_thresh = sub_cfg.and_then(|c| c.warn_threshold).map(|t| -t);
-        let c_thresh = sub_cfg.and_then(|c| c.critical_threshold).map(|t| -t);
-        let w_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-        let c_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-        (Some(-val), w_thresh, w_style, c_thresh, c_style)
-    } else {
-        let w_thresh = sub_cfg
-            .and_then(|c| c.warn_threshold)
-            .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-        let c_thresh = sub_cfg
-            .and_then(|c| c.critical_threshold)
-            .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-        let w_style = sub_cfg
-            .and_then(|c| c.warn_style.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-        let c_style = sub_cfg
-            .and_then(|c| c.critical_style.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-        (Some(val), w_thresh, w_style, c_thresh, c_style)
-    };
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            effective_val,
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
-        effective_val,
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        Some(val),
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.size` — reads `context_window_size` field (not `size`).
@@ -182,47 +99,12 @@ pub fn render_size(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.total_input_tokens`.
@@ -247,47 +129,12 @@ pub fn render_total_input_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<Str
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.total_output_tokens`.
@@ -312,47 +159,12 @@ pub fn render_total_output_tokens(ctx: &Context, cfg: &CshipConfig) -> Option<St
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.exceeds_200k`.
@@ -404,47 +216,12 @@ pub fn render_current_usage_input_tokens(ctx: &Context, cfg: &CshipConfig) -> Op
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.current_usage.output_tokens`.
@@ -472,47 +249,12 @@ pub fn render_current_usage_output_tokens(ctx: &Context, cfg: &CshipConfig) -> O
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.current_usage.cache_creation_input_tokens`.
@@ -543,47 +285,12 @@ pub fn render_current_usage_cache_creation_input_tokens(
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 /// Renders `$cship.context_window.current_usage.cache_read_input_tokens`.
@@ -614,47 +321,12 @@ pub fn render_current_usage_cache_read_input_tokens(
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg
-        .and_then(|c| c.style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.style.as_deref()));
-    let warn_threshold = sub_cfg
-        .and_then(|c| c.warn_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.warn_threshold));
-    let warn_style = sub_cfg
-        .and_then(|c| c.warn_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.warn_style.as_deref()));
-    let critical_threshold = sub_cfg
-        .and_then(|c| c.critical_threshold)
-        .or_else(|| cw_cfg.and_then(|c| c.critical_threshold));
-    let critical_style = sub_cfg
-        .and_then(|c| c.critical_style.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.critical_style.as_deref()));
-    if let Some(fmt) = sub_cfg
-        .and_then(|c| c.format.as_deref())
-        .or_else(|| cw_cfg.and_then(|c| c.format.as_deref()))
-    {
-        let symbol = sub_cfg
-            .and_then(|c| c.symbol.as_deref())
-            .or_else(|| cw_cfg.and_then(|c| c.symbol.as_deref()));
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
+    crate::format::render_styled_value(
         &val_str,
         Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        sub_cfg,
+        cw_cfg.map(|c| c as &dyn crate::config::HasThresholdStyle),
+    )
 }
 
 #[cfg(test)]

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -6,7 +6,9 @@
 /// `$cship.cost.total_lines_added` / `total_lines_removed` — integer counts.
 ///
 /// [Source: epics.md#Story 2.1, architecture.md#Structure Patterns]
-use crate::config::{CostConfig, CostSubfieldConfig, CshipConfig};
+use crate::config::{CostConfig, CshipConfig};
+#[cfg(test)]
+use crate::config::CostSubfieldConfig;
 use crate::context::Context;
 
 /// Renders `$cship.cost` — total cost as `$X.XX` with threshold color escalation.
@@ -80,33 +82,7 @@ pub fn render_total_cost_usd(ctx: &Context, cfg: &CshipConfig) -> Option<String>
         }
     };
     let val_str = format!("{:.4}", val);
-    let style = sub_cfg.and_then(|c| c.style.as_deref());
-    // Extract threshold variables FIRST (before format check)
-    let warn_threshold = sub_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = sub_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-    if let Some(fmt) = sub_cfg.and_then(|c| c.format.as_deref()) {
-        let symbol = sub_cfg.and_then(|c| c.symbol.as_deref());
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
-        &val_str,
-        Some(val),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+    crate::format::render_styled_value(&val_str, Some(val), sub_cfg, None)
 }
 
 /// Renders `$cship.cost.total_duration_ms` — total wall time in milliseconds.
@@ -124,33 +100,7 @@ pub fn render_total_duration_ms(ctx: &Context, cfg: &CshipConfig) -> Option<Stri
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg.and_then(|c| c.style.as_deref());
-    // Extract threshold variables FIRST (before format check)
-    let warn_threshold = sub_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = sub_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-    if let Some(fmt) = sub_cfg.and_then(|c| c.format.as_deref()) {
-        let symbol = sub_cfg.and_then(|c| c.symbol.as_deref());
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
-        &val_str,
-        Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+    crate::format::render_styled_value(&val_str, Some(val as f64), sub_cfg, None)
 }
 
 /// Renders `$cship.cost.total_api_duration_ms` — API-only duration in milliseconds.
@@ -168,33 +118,7 @@ pub fn render_total_api_duration_ms(ctx: &Context, cfg: &CshipConfig) -> Option<
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg.and_then(|c| c.style.as_deref());
-    // Extract threshold variables FIRST (before format check)
-    let warn_threshold = sub_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = sub_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-    if let Some(fmt) = sub_cfg.and_then(|c| c.format.as_deref()) {
-        let symbol = sub_cfg.and_then(|c| c.symbol.as_deref());
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
-        &val_str,
-        Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+    crate::format::render_styled_value(&val_str, Some(val as f64), sub_cfg, None)
 }
 
 /// Renders `$cship.cost.total_lines_added` — cumulative lines added this session.
@@ -212,33 +136,7 @@ pub fn render_total_lines_added(ctx: &Context, cfg: &CshipConfig) -> Option<Stri
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg.and_then(|c| c.style.as_deref());
-    // Extract threshold variables FIRST (before format check)
-    let warn_threshold = sub_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = sub_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-    if let Some(fmt) = sub_cfg.and_then(|c| c.format.as_deref()) {
-        let symbol = sub_cfg.and_then(|c| c.symbol.as_deref());
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
-        &val_str,
-        Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+    crate::format::render_styled_value(&val_str, Some(val as f64), sub_cfg, None)
 }
 
 /// Renders `$cship.cost.total_lines_removed` — cumulative lines removed this session.
@@ -256,37 +154,11 @@ pub fn render_total_lines_removed(ctx: &Context, cfg: &CshipConfig) -> Option<St
         }
     };
     let val_str = val.to_string();
-    let style = sub_cfg.and_then(|c| c.style.as_deref());
-    // Extract threshold variables FIRST (before format check)
-    let warn_threshold = sub_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = sub_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = sub_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = sub_cfg.and_then(|c| c.critical_style.as_deref());
-    if let Some(fmt) = sub_cfg.and_then(|c| c.format.as_deref()) {
-        let symbol = sub_cfg.and_then(|c| c.symbol.as_deref());
-        let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val as f64),
-            style,
-            warn_threshold,
-            warn_style,
-            critical_threshold,
-            critical_style,
-        );
-        return crate::format::apply_module_format(fmt, Some(&val_str), symbol, effective_style);
-    }
-    Some(crate::ansi::apply_style_with_threshold(
-        &val_str,
-        Some(val as f64),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+    crate::format::render_styled_value(&val_str, Some(val as f64), sub_cfg, None)
 }
 
 fn is_subfield_disabled(
-    sub_cfg: Option<&CostSubfieldConfig>,
+    sub_cfg: Option<&crate::config::SubfieldConfig>,
     cost_cfg: Option<&CostConfig>,
 ) -> bool {
     // Sub-field explicit disabled takes precedence


### PR DESCRIPTION
## Summary

- Replace `CostSubfieldConfig` and `ContextWindowSubfieldConfig` with a single `SubfieldConfig` type
- Add `HasThresholdStyle` trait for uniform access to style/threshold fields across parent configs
- Add `render_styled_value()` helper in `format.rs` that centralizes the style/threshold/format rendering pipeline
- Refactor 14 sub-field render functions in `context_window.rs` and `cost.rs` to use the new helper, reducing each from ~40-60 lines to ~15 lines
- No behavioral changes, all existing tests pass

## Files changed

| File | Change |
|---|---|
| `src/config.rs` | Unified `SubfieldConfig`, `HasThresholdStyle` trait with macro |
| `src/format.rs` | Added `render_styled_value()` with 6 unit tests |
| `src/modules/context_window.rs` | 9 sub-field functions refactored to use helper |
| `src/modules/cost.rs` | 5 sub-field functions refactored to use helper |

## Test plan

- [ ] `cargo test` passes (291 unit + 65 integration)
- [ ] `cargo clippy` clean
- [ ] `cargo build --release` clean