### PR TITLE
Add currency symbol and conversion rate to cost module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,10 @@ pub struct CostConfig {
     pub critical_threshold: Option<f64>,
     pub critical_style: Option<String>,
     pub format: Option<String>,
+    /// Currency symbol to display instead of `$`. Defaults to `$`.
+    pub currency_symbol: Option<String>,
+    /// Conversion rate from USD to the target currency. Defaults to 1.0 (no conversion).
+    pub conversion_rate: Option<f64>,
     // Sub-field per-display configs (map to [cship.cost.total_cost_usd] etc.)
     pub total_cost_usd: Option<CostSubfieldConfig>,
     pub total_duration_ms: Option<CostSubfieldConfig>,

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -29,7 +29,10 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
 
     let symbol = cost_cfg.and_then(|c| c.symbol.as_deref());
     let style = cost_cfg.and_then(|c| c.style.as_deref());
-    let formatted = format!("${:.2}", val);
+    let currency_symbol = cost_cfg.and_then(|c| c.currency_symbol.as_deref()).unwrap_or("$");
+    let conversion_rate = cost_cfg.and_then(|c| c.conversion_rate).unwrap_or(1.0);
+    let converted_val = val * conversion_rate;
+    let formatted = format!("{}{:.2}", currency_symbol, converted_val);
 
     // Extract threshold variables FIRST (before format check)
     let warn_threshold = cost_cfg.and_then(|c| c.warn_threshold);
@@ -321,6 +324,35 @@ mod tests {
         let ctx = ctx_with_cost(0.01234);
         let result = render(&ctx, &CshipConfig::default());
         assert_eq!(result, Some("$0.01".to_string()));
+    }
+
+    #[test]
+    fn test_cost_renders_custom_currency_symbol() {
+        let ctx = ctx_with_cost(1.50);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                currency_symbol: Some("£".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg);
+        assert_eq!(result, Some("£1.50".to_string()));
+    }
+
+    #[test]
+    fn test_cost_renders_with_conversion_rate() {
+        let ctx = ctx_with_cost(1.00);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                currency_symbol: Some("£".to_string()),
+                conversion_rate: Some(0.79),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg);
+        assert_eq!(result, Some("£0.79".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `currency_symbol` config option to `[cship.cost]` — defaults to `$`, can be set to any string (e.g. `£`, `€`)
- Adds `conversion_rate` config option — defaults to `1.0`, multiplies the USD value before display
- Includes tests for both new options

### Example config

```toml
[cship.cost]
currency_symbol = "£"
conversion_rate = 0.79
```

This displays the cost as `£0.79` instead of `$1.00`.

Closes #110

## Test plan

- [ ] Existing cost tests still pass
- [ ] New test: custom currency symbol renders correctly
- [ ] New test: conversion rate applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)