### PR TITLE
feat: add {remaining} placeholder for usage_limits format strings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,8 +304,8 @@ Displays 5-hour and 7-day API utilization percentages with time-to-reset. Fetche
 | `disabled` | `bool` | `false` | Hide this module |
 | `style` | `string` | — | Base ANSI style |
 | `format` | `string` | — | Format string |
-| `five_hour_format` | `string` | `"5h: {pct}% resets in {reset}"` | Format for the 5h window; `{pct}` and `{reset}` are placeholders |
-| `seven_day_format` | `string` | `"7d: {pct}% resets in {reset}"` | Format for the 7d window |
+| `five_hour_format` | `string` | `"5h: {pct}% resets in {reset}"` | Format for the 5h window. Placeholders: `{pct}` (% used), `{remaining}` (% left), `{reset}` (time to reset) |
+| `seven_day_format` | `string` | `"7d: {pct}% resets in {reset}"` | Format for the 7d window. Same placeholders as above |
 | `separator` | `string` | `" \| "` | String placed between 5h and 7d sections |
 | `warn_threshold` | `float` | — | % at which style switches to `warn_style` |
 | `warn_style` | `string` | `"yellow"` | Style at warn level |
@@ -318,8 +318,8 @@ Displays 5-hour and 7-day API utilization percentages with time-to-reset. Fetche
 ```toml
 [cship.usage_limits]
 ttl                = 300       # 5 minutes; increase if you run many concurrent sessions
-five_hour_format   = "5h {pct}%({reset})"
-seven_day_format   = "7d {pct}%({reset})"
+five_hour_format   = "5h({remaining}% left)"
+seven_day_format   = "7d({remaining}% left)"
 separator          = " "
 warn_threshold     = 70.0
 warn_style         = "bold yellow"

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -114,7 +114,8 @@ where
 /// Format usage data using configurable format strings.
 ///
 /// Placeholders in format strings (all occurrences are substituted):
-/// - `{pct}` — percentage as integer (e.g. `"23"`)
+/// - `{pct}` — percentage used as integer (e.g. `"23"`)
+/// - `{remaining}` — percentage remaining as integer (e.g. `"77"`)
 /// - `{reset}` — time-until-reset string (e.g. `"4h12m"`)
 ///
 /// Defaults (backwards compatible with pre-7.2 hardcoded output):
@@ -123,8 +124,10 @@ where
 /// - `separator`: `" | "`
 fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     let five_h_pct = format!("{:.0}", data.five_hour_pct);
+    let five_h_remaining = format!("{:.0}", (100.0 - data.five_hour_pct).max(0.0));
     let five_h_reset = format_time_until(&data.five_hour_resets_at);
     let seven_d_pct = format!("{:.0}", data.seven_day_pct);
+    let seven_d_remaining = format!("{:.0}", (100.0 - data.seven_day_pct).max(0.0));
     let seven_d_reset = format_time_until(&data.seven_day_resets_at);
 
     let five_h_fmt = cfg
@@ -139,9 +142,11 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
 
     let five_h_part = five_h_fmt
         .replace("{pct}", &five_h_pct)
+        .replace("{remaining}", &five_h_remaining)
         .replace("{reset}", &five_h_reset);
     let seven_d_part = seven_d_fmt
         .replace("{pct}", &seven_d_pct)
+        .replace("{remaining}", &seven_d_remaining)
         .replace("{reset}", &seven_d_reset);
 
     format!("{five_h_part}{sep}{seven_d_part}")


### PR DESCRIPTION
## Summary

Adds a `{remaining}` placeholder to `five_hour_format` and `seven_day_format` that shows the percentage of usage **remaining** (`100 - used`). Fully backwards compatible — defaults unchanged, existing `{pct}` and `{reset}` placeholders unaffected.

## Motivation

When monitoring rate limits, "how much do I have left" is often more intuitive than "how much have I used." This gives users the choice.

## Example

```toml
[cship.usage_limits]
five_hour_format = "5h({remaining}% left)"
seven_day_format = "7d({remaining}% left)"
```

Renders: `5h(77% left) · 7d(99% left)` when 23% / 1% is used.