### PR TITLE
refactor: remove #[cfg(test)] type aliases for old config types

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -101,29 +101,6 @@ pub trait HasThresholdStyle {
     }
 }
 
-#[allow(unused_macros)]
-macro_rules! impl_has_threshold_style {
-    ($t:ty) => {
-        impl HasThresholdStyle for $t {
-            fn style(&self) -> Option<&str> {
-                self.style.as_deref()
-            }
-            fn warn_threshold(&self) -> Option<f64> {
-                self.warn_threshold
-            }
-            fn warn_style(&self) -> Option<&str> {
-                self.warn_style.as_deref()
-            }
-            fn critical_threshold(&self) -> Option<f64> {
-                self.critical_threshold
-            }
-            fn critical_style(&self) -> Option<&str> {
-                self.critical_style.as_deref()
-            }
-        }
-    };
-}
-
 /// Configuration for `[cship.context_bar]` — visual progress bar with thresholds.
 /// Implemented in Story 2.2. Defined here so all Epic 2 config is available.
 #[derive(Debug, Deserialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,12 +81,6 @@ pub struct SubfieldConfig {
     pub invert_threshold: Option<bool>,
 }
 
-/// Backwards-compatible type aliases (used by test code).
-#[cfg(test)]
-pub type CostSubfieldConfig = SubfieldConfig;
-#[cfg(test)]
-pub type ContextWindowSubfieldConfig = SubfieldConfig;
-
 /// Trait for uniform access to style/threshold fields shared by config types.
 /// Used by `render_styled_value()` to resolve sub-field → parent fallback.
 ///

--- a/src/modules/context_window.rs
+++ b/src/modules/context_window.rs
@@ -51,7 +51,7 @@ pub fn render_used_percentage(ctx: &Context, cfg: &CshipConfig) -> Option<String
 ///
 /// ## `invert_threshold` contract
 ///
-/// When [`crate::config::ContextWindowSubfieldConfig::invert_threshold`] is `true`:
+/// When [`crate::config::SubfieldConfig::invert_threshold`] is `true`:
 /// - `warn_threshold`, `warn_style`, `critical_threshold`, and `critical_style` are resolved
 ///   from the **sub-field config only** (`[cship.context_window.remaining_percentage]`).
 ///   Parent [`crate::config::ContextWindowConfig`] threshold values are **not** inherited — they live in the
@@ -404,7 +404,7 @@ pub fn render_current_usage_cache_read_input_tokens(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ContextWindowConfig, ContextWindowSubfieldConfig, CshipConfig};
+    use crate::config::{ContextWindowConfig, SubfieldConfig, CshipConfig};
     use crate::context::{Context, ContextWindow, CurrentUsage};
 
     fn ctx_full() -> Context {
@@ -589,7 +589,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(95.0),
@@ -624,7 +624,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(95.0),
@@ -659,7 +659,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -708,7 +708,7 @@ mod tests {
         let ctx = ctx_full(); // used_percentage=35, remaining_percentage=65
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     disabled: Some(true),
                     ..Default::default()
                 }),
@@ -737,7 +737,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     format: Some("[$value%]($style)".to_string()),
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
@@ -772,7 +772,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                size: Some(ContextWindowSubfieldConfig {
+                size: Some(SubfieldConfig {
                     warn_threshold: Some(150000.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -801,7 +801,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                total_input_tokens: Some(ContextWindowSubfieldConfig {
+                total_input_tokens: Some(SubfieldConfig {
                     warn_threshold: Some(150000.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -828,7 +828,7 @@ mod tests {
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
                 style: Some("green".to_string()),
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     style: Some("blue".to_string()),
                     ..Default::default()
                 }),
@@ -860,7 +860,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                remaining_percentage: Some(ContextWindowSubfieldConfig {
+                remaining_percentage: Some(SubfieldConfig {
                     invert_threshold: Some(true),
                     warn_threshold: Some(20.0),
                     warn_style: Some("yellow".to_string()),
@@ -892,7 +892,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                remaining_percentage: Some(ContextWindowSubfieldConfig {
+                remaining_percentage: Some(SubfieldConfig {
                     invert_threshold: Some(true),
                     warn_threshold: Some(20.0),
                     warn_style: Some("yellow".to_string()),
@@ -921,7 +921,7 @@ mod tests {
         };
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                remaining_percentage: Some(ContextWindowSubfieldConfig {
+                remaining_percentage: Some(SubfieldConfig {
                     invert_threshold: Some(true),
                     warn_threshold: Some(20.0),
                     warn_style: Some("yellow".to_string()),
@@ -955,7 +955,7 @@ mod tests {
             context_window: Some(ContextWindowConfig {
                 warn_threshold: Some(80.0), // parent: warn when 80% USED
                 warn_style: Some("yellow".to_string()),
-                remaining_percentage: Some(ContextWindowSubfieldConfig {
+                remaining_percentage: Some(SubfieldConfig {
                     invert_threshold: Some(true),
                     // no subfield thresholds set → nothing fires
                     ..Default::default()
@@ -978,7 +978,7 @@ mod tests {
         let result_default = render_used_percentage(&ctx, &CshipConfig::default());
         let cfg_no_thresh = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_percentage: Some(ContextWindowSubfieldConfig {
+                used_percentage: Some(SubfieldConfig {
                     ..Default::default() // all None
                 }),
                 ..Default::default()
@@ -1017,7 +1017,7 @@ mod tests {
         let ctx = ctx_used_tokens(85.0);
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_tokens: Some(ContextWindowSubfieldConfig {
+                used_tokens: Some(SubfieldConfig {
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(95.0),
@@ -1049,7 +1049,7 @@ mod tests {
         let ctx = ctx_used_tokens(97.0);
         let cfg = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_tokens: Some(ContextWindowSubfieldConfig {
+                used_tokens: Some(SubfieldConfig {
                     warn_threshold: Some(80.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(95.0),
@@ -1082,7 +1082,7 @@ mod tests {
         let result_default = render_used_tokens(&ctx, &CshipConfig::default()).unwrap();
         let cfg_no_thresh = CshipConfig {
             context_window: Some(ContextWindowConfig {
-                used_tokens: Some(ContextWindowSubfieldConfig {
+                used_tokens: Some(SubfieldConfig {
                     ..Default::default() // all None
                 }),
                 ..Default::default()

--- a/src/modules/context_window.rs
+++ b/src/modules/context_window.rs
@@ -404,7 +404,7 @@ pub fn render_current_usage_cache_read_input_tokens(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ContextWindowConfig, SubfieldConfig, CshipConfig};
+    use crate::config::{ContextWindowConfig, CshipConfig, SubfieldConfig};
     use crate::context::{Context, ContextWindow, CurrentUsage};
 
     fn ctx_full() -> Context {

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::config::CostSubfieldConfig;
+use crate::config::SubfieldConfig;
 /// Render the `[cship.cost]` family of modules.
 ///
 /// `$cship.cost` — convenience alias: formats total_cost_usd as "$X.XX" with threshold styling.
@@ -450,7 +450,7 @@ mod tests {
         let ctx = ctx_with_cost(5.0); // total_cost_usd = 5.0
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_cost_usd: Some(CostSubfieldConfig {
+                total_cost_usd: Some(SubfieldConfig {
                     warn_threshold: Some(3.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(10.0),
@@ -475,7 +475,7 @@ mod tests {
         let ctx = ctx_with_cost(12.0); // total_cost_usd = 12.0
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_cost_usd: Some(CostSubfieldConfig {
+                total_cost_usd: Some(SubfieldConfig {
                     warn_threshold: Some(3.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(10.0),
@@ -500,7 +500,7 @@ mod tests {
         let ctx = ctx_with_cost(1.0); // below warn_threshold of 3.0
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_cost_usd: Some(CostSubfieldConfig {
+                total_cost_usd: Some(SubfieldConfig {
                     warn_threshold: Some(3.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -523,7 +523,7 @@ mod tests {
         let ctx = ctx_with_cost(0.01); // ctx_with_cost sets total_duration_ms = 45000
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_duration_ms: Some(CostSubfieldConfig {
+                total_duration_ms: Some(SubfieldConfig {
                     warn_threshold: Some(30000.0),
                     warn_style: Some("yellow".to_string()),
                     critical_threshold: Some(60000.0),
@@ -545,7 +545,7 @@ mod tests {
         let ctx = ctx_with_cost(0.01); // total_duration_ms = 45000 > 30000
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_duration_ms: Some(CostSubfieldConfig {
+                total_duration_ms: Some(SubfieldConfig {
                     format: Some("[$value ms]($style)".to_string()),
                     warn_threshold: Some(30000.0),
                     warn_style: Some("yellow".to_string()),
@@ -574,7 +574,7 @@ mod tests {
         let ctx = ctx_with_cost(0.01); // ctx_with_cost sets total_api_duration_ms = 2300
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_api_duration_ms: Some(CostSubfieldConfig {
+                total_api_duration_ms: Some(SubfieldConfig {
                     warn_threshold: Some(2000.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -594,7 +594,7 @@ mod tests {
         let ctx = ctx_with_cost(0.01); // ctx_with_cost sets total_lines_added = 156
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_lines_added: Some(CostSubfieldConfig {
+                total_lines_added: Some(SubfieldConfig {
                     warn_threshold: Some(100.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -614,7 +614,7 @@ mod tests {
         let ctx = ctx_with_cost(0.01); // ctx_with_cost sets total_lines_removed = 23
         let cfg = CshipConfig {
             cost: Some(CostConfig {
-                total_lines_removed: Some(CostSubfieldConfig {
+                total_lines_removed: Some(SubfieldConfig {
                     warn_threshold: Some(10.0),
                     warn_style: Some("yellow".to_string()),
                     ..Default::default()
@@ -635,7 +635,7 @@ mod tests {
         let result_default = render_total_cost_usd(&ctx, &CshipConfig::default());
         let cfg_no_thresh = CshipConfig {
             cost: Some(CostConfig {
-                total_cost_usd: Some(CostSubfieldConfig {
+                total_cost_usd: Some(SubfieldConfig {
                     ..Default::default() // all None
                 }),
                 ..Default::default()

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::config::SubfieldConfig;
 /// Render the `[cship.cost]` family of modules.
 ///
 /// `$cship.cost` — convenience alias: formats total_cost_usd as "$X.XX" with threshold styling.
@@ -172,7 +170,7 @@ fn is_subfield_disabled(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CostConfig, CshipConfig};
+    use crate::config::{CostConfig, CshipConfig, SubfieldConfig};
     use crate::context::{Context, Cost};
 
     fn ctx_with_cost(usd: f64) -> Context {


### PR DESCRIPTION
## Summary

- Removes `#[cfg(test)]` type aliases `CostSubfieldConfig` and `ContextWindowSubfieldConfig` from `src/config.rs`.
- Removes the now-unused `impl_has_threshold_style!` macro.
- Updates all test files to use `SubfieldConfig` directly.

_Re-submission of PR #128 after revert. Depends on PR #132._

## Test plan

- [ ] `cargo build` exits 0 with no errors
- [ ] `cargo test` passes all tests with no regressions
- [ ] `cargo clippy -- -D warnings` exits 0 (no new warnings introduced)
- [ ] Confirm `CostSubfieldConfig` and `ContextWindowSubfieldConfig` type aliases are fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)