### PR TITLE
feat(context_bar): render 0% empty bar when context data is absent. fixes #105

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 ## Non-Negotiable Code Patterns
 - Module interface (never deviate): `pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String>`
 - Disabled flag → silent `None` (no warn); absent data → explicit `match` + `tracing::warn!` + `None`
+  - Exception: `context_bar` intentionally renders a 0% empty bar (styled via `empty_style`) when `context_window` is absent, rather than returning `None`. This is a deliberate UX choice — showing an empty bar is more informative than showing nothing. It uses `tracing::debug!` (not `warn!`) because absence is the normal state at session start.
 - Never use `?` operator on paths that require a warning — use explicit `match`
 - stdout owned by `main.rs` only; all module diagnostics via `tracing::*` macros; no `eprintln!` anywhere
 - Exception: CLI-action subcommands (e.g. `uninstall`, `explain`) may use `println!` directly — the stdout rule applies to the rendering pipeline only

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,7 @@ Renders a visual ASCII progress bar showing context window usage.
 | `warn_style` | `string` | `"yellow"` | Style at warn level |
 | `critical_threshold` | `float` | — | % at which style switches to `critical_style` |
 | `critical_style` | `string` | `"bold red"` | Style at critical level |
+| `empty_style` | `string` | — | Style for the bar when no context data is available (e.g., `"dim"`) |
 
 ```toml
 [cship.context_bar]

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,9 @@ pub struct ContextBarConfig {
     pub critical_style: Option<String>,
     pub width: Option<u32>,
     pub format: Option<String>,
+    /// Style applied when rendering the bar at 0% due to absent context data.
+    /// Example: `"dim"` to visually distinguish the empty state.
+    pub empty_style: Option<String>,
 }
 
 /// Configuration for `[cship.context_window]` sub-field modules.

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -19,7 +19,9 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         Some(cw) => match cw.used_percentage {
             Some(v) => (v, false),
             None => {
-                tracing::debug!("cship.context_bar: context_window present but used_percentage absent; rendering empty bar");
+                tracing::debug!(
+                    "cship.context_bar: context_window present but used_percentage absent; rendering empty bar"
+                );
                 (0.0f64, true)
             }
         },
@@ -44,7 +46,12 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     if is_empty {
         let empty_style = bar_cfg.and_then(|c| c.empty_style.as_deref());
         if let Some(fmt) = bar_cfg.and_then(|c| c.format.as_deref()) {
-            return crate::format::apply_module_format(fmt, Some(&bar_content), symbol, empty_style);
+            return crate::format::apply_module_format(
+                fmt,
+                Some(&bar_content),
+                symbol,
+                empty_style,
+            );
         }
         return Some(crate::ansi::apply_style(&bar_content, empty_style));
     }
@@ -137,8 +144,7 @@ mod tests {
         let result = render(&ctx, &CshipConfig::default()).unwrap();
         let empty_count: usize = result.chars().filter(|&c| c == '░').count();
         assert_eq!(
-            empty_count,
-            DEFAULT_BAR_WIDTH as usize,
+            empty_count, DEFAULT_BAR_WIDTH as usize,
             "all chars should be empty: {result:?}"
         );
         assert!(result.contains("0%"), "should show 0%: {result:?}");

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -15,12 +15,14 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         return None;
     }
 
-    let (used_pct, is_empty) = match ctx
-        .context_window
-        .as_ref()
-        .and_then(|cw| cw.used_percentage)
-    {
-        Some(v) => (v, false),
+    let (used_pct, is_empty) = match ctx.context_window.as_ref() {
+        Some(cw) => match cw.used_percentage {
+            Some(v) => (v, false),
+            None => {
+                tracing::debug!("cship.context_bar: context_window present but used_percentage absent; rendering empty bar");
+                (0.0f64, true)
+            }
+        },
         None => (0.0f64, true),
     };
 

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -15,16 +15,13 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         return None;
     }
 
-    let used_pct = match ctx
+    let (used_pct, is_empty) = match ctx
         .context_window
         .as_ref()
         .and_then(|cw| cw.used_percentage)
     {
-        Some(v) => v,
-        None => {
-            tracing::warn!("cship.context_bar: used_percentage absent from context");
-            return None;
-        }
+        Some(v) => (v, false),
+        None => (0.0f64, true),
     };
 
     let width = bar_cfg.and_then(|c| c.width).unwrap_or(DEFAULT_BAR_WIDTH) as usize;
@@ -40,6 +37,15 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
 
     let symbol = bar_cfg.and_then(|c| c.symbol.as_deref());
     let style = bar_cfg.and_then(|c| c.style.as_deref());
+
+    // Absent context: render 0% bar styled with empty_style (AC: 1, 2, 3)
+    if is_empty {
+        let empty_style = bar_cfg.and_then(|c| c.empty_style.as_deref());
+        if let Some(fmt) = bar_cfg.and_then(|c| c.format.as_deref()) {
+            return crate::format::apply_module_format(fmt, Some(&bar_content), symbol, empty_style);
+        }
+        return Some(crate::ansi::apply_style(&bar_content, empty_style));
+    }
 
     // Extract threshold variables FIRST (before format check)
     let warn_threshold = bar_cfg.and_then(|c| c.warn_threshold);
@@ -124,9 +130,57 @@ mod tests {
     }
 
     #[test]
-    fn test_context_bar_absent_context_window_returns_none() {
-        let ctx = Context::default();
-        assert_eq!(render(&ctx, &CshipConfig::default()), None);
+    fn test_context_bar_absent_context_window_renders_empty_bar() {
+        let ctx = Context::default(); // context_window is None
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        let empty_count: usize = result.chars().filter(|&c| c == '░').count();
+        assert_eq!(
+            empty_count,
+            DEFAULT_BAR_WIDTH as usize,
+            "all chars should be empty: {result:?}"
+        );
+        assert!(result.contains("0%"), "should show 0%: {result:?}");
+        assert!(!result.contains('█'), "no filled chars: {result:?}");
+    }
+
+    #[test]
+    fn test_context_bar_absent_with_empty_style_applies_ansi() {
+        let ctx = Context::default(); // context_window is None
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                empty_style: Some("dimmed".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected ANSI codes for empty_style dimmed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_absent_no_empty_style_no_ansi() {
+        let ctx = Context::default(); // context_window is None
+        let result = render(&ctx, &CshipConfig::default()).unwrap();
+        assert!(
+            !result.contains('\x1b'),
+            "expected no ANSI codes when no style configured: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_context_bar_disabled_absent_returns_none() {
+        let ctx = Context::default(); // context_window is None
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Renders the context bar at 0% (all empty chars) when context data is absent, instead of returning `None`
- Added `empty_style` config field to `ContextBarConfig` for styling the empty/zero state
- Added `tracing::debug!` for observability when `context_window` is present but `used_percentage` is absent

## Test plan

- [x] All 322 unit tests pass
- [x] All 66 integration tests pass
- [x] Context bar renders visually at 0% when no context data is available
- [x] `empty_style` config field correctly styles the empty bar state
- [x] `tracing::debug!` fires correctly when `context_window` is present but `used_percentage` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)