### PR TITLE
fix(install.ps1): harden arch detection and increase ConvertTo-Json depth

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,8 +20,8 @@ $SETTINGS    = Join-Path $env:APPDATA "Claude\settings.json"
 # --- Arch detection ---
 $arch = $env:PROCESSOR_ARCHITECTURE
 # WOW64: 32-bit PowerShell on 64-bit OS reports x86; check redirection variable
-if ($arch -eq "x86" -and $env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
-    $arch = "AMD64"
+if ($arch -eq "x86" -and $env:PROCESSOR_ARCHITEW6432) {
+    $arch = $env:PROCESSOR_ARCHITEW6432
 }
 if ($arch -eq "AMD64") {
     $TARGET = "x86_64-pc-windows-msvc"

--- a/install.ps1
+++ b/install.ps1
@@ -19,6 +19,10 @@ $SETTINGS    = Join-Path $env:APPDATA "Claude\settings.json"
 
 # --- Arch detection ---
 $arch = $env:PROCESSOR_ARCHITECTURE
+# WOW64: 32-bit PowerShell on 64-bit OS reports x86; check redirection variable
+if ($arch -eq "x86" -and $env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
+    $arch = "AMD64"
+}
 if ($arch -eq "AMD64") {
     $TARGET = "x86_64-pc-windows-msvc"
 } elseif ($arch -eq "ARM64") {
@@ -99,7 +103,7 @@ if (-not (Test-Path $claudeDir)) {
     } else {
         $json.statusline = "cship"
     }
-    $json | ConvertTo-Json -Depth 10 | Set-Content -Path $SETTINGS -Encoding UTF8
+    $json | ConvertTo-Json -Depth 100 | Set-Content -Path $SETTINGS -Encoding UTF8
     Write-Host "Updated settings.json with statusline entry."
 }
 


### PR DESCRIPTION
## Summary

- Fixes WOW64 arch detection: when PowerShell runs as 32-bit on a 64-bit OS, `PROCESSOR_ARCHITECTURE` reports `x86`; the fix checks `PROCESSOR_ARCHITEW6432` to get the true host architecture (supports both AMD64 and ARM64 hosts)
- Increases `ConvertTo-Json -Depth` from 10 to 100 to prevent truncation of deeply nested `settings.json` structures

## Test plan

- [ ] Verify installer correctly detects `x86_64-pc-windows-msvc` target on AMD64 machines running 32-bit PowerShell (WOW64)
- [ ] Verify installer correctly detects `aarch64-pc-windows-msvc` target on ARM64 machines running 32-bit PowerShell (WOW64)
- [ ] Verify `settings.json` is written without truncation when it contains deeply nested JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)