### PR TITLE
fix(platform): restore compile guard for unsupported OS targets and clarify CLAUDE_HOME semantics

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -102,6 +102,11 @@ fn read_credentials_file() -> Option<String> {
 /// 1. `CLAUDE_HOME` env var (explicit override for non-standard installs, all platforms)
 /// 2. `HOME` env var (Unix standard; also set by Git Bash / WSL on Windows)
 /// 3. `USERPROFILE` env var (Windows native; Claude Code stores .claude here)
+///
+/// # Note on `CLAUDE_HOME`
+///
+/// `CLAUDE_HOME` must point to the *parent* of `.claude`, not to `.claude` itself.
+/// e.g. `CLAUDE_HOME=/home/user` (the parent of `.claude`, not `.claude` itself)
 pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
     for var in ["CLAUDE_HOME", "HOME", "USERPROFILE"] {
         if let Ok(h) = std::env::var(var)
@@ -129,6 +134,9 @@ pub fn get_oauth_token() -> Result<String, String> {
         "Claude Code credentials found but access token could not be parsed — credential may be malformed".into()
     })
 }
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+compile_error!("cship: get_oauth_token() is only supported on macOS, Linux, and Windows");
 
 /// Inner implementation with injectable command name for testability.
 /// `tool` is the binary; `args` are the arguments passed to it.


### PR DESCRIPTION
## Summary

- Add `compile_error\!` for any `target_os` that is not `macos`, `linux`, or `windows`, preventing cryptic linker failures on unsupported platforms (FreeBSD, illumos, etc.)
- Update `home_dir()` doc comment with a concrete `CLAUDE_HOME` example clarifying it must point to the parent of `.claude`, not `.claude` itself

Implements story 9.1 (AC #1, #2, #3). All 65 applicable tests pass.

## Test plan

- [ ] `cargo build` succeeds on macOS, Linux, and Windows
- [ ] Attempting to compile on an unsupported OS produces a clear `compile_error\!` message
- [ ] `cargo test` passes (all 65 tests green)
- [ ] `cargo clippy -- -D warnings` passes with no warnings
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)