### PR TITLE
fix(uninstall): align Windows uninstaller paths with installer

### DIFF
--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -16,12 +16,29 @@ pub fn run() {
 
 fn remove_binary(home: &std::path::Path) {
     #[cfg(not(target_os = "windows"))]
-    let candidates = [home.join(".local/bin/cship"), home.join(".cargo/bin/cship")];
+    let candidates = vec![home.join(".local/bin/cship"), home.join(".cargo/bin/cship")];
     #[cfg(target_os = "windows")]
-    let candidates = [
-        home.join(".cargo/bin/cship.exe"),
-        home.join(r".local\bin\cship.exe"),
-    ];
+    let candidates = {
+        let mut v: Vec<std::path::PathBuf> = Vec::new();
+        match std::env::var("LOCALAPPDATA") {
+            Ok(local_app_data) => {
+                v.push(
+                    std::path::Path::new(&local_app_data)
+                        .join("Programs")
+                        .join("cship")
+                        .join("cship.exe"),
+                );
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "LOCALAPPDATA env var not set; skipping %LOCALAPPDATA%\\Programs\\cship\\cship.exe candidate"
+                );
+            }
+        }
+        v.push(home.join(".cargo/bin/cship.exe"));
+        v.push(home.join(r".local\bin\cship.exe"));
+        v
+    };
     for bin in candidates {
         if bin.exists() {
             match std::fs::remove_file(&bin) {
@@ -35,7 +52,21 @@ fn remove_binary(home: &std::path::Path) {
 }
 
 fn remove_statusline_from_settings(home: &std::path::Path) {
+    #[cfg(target_os = "windows")]
+    let path = match std::env::var("APPDATA") {
+        Ok(app_data) => std::path::Path::new(&app_data)
+            .join("Claude")
+            .join("settings.json"),
+        Err(_) => {
+            tracing::warn!(
+                "APPDATA env var not set; falling back to ~/.claude/settings.json for settings path"
+            );
+            home.join(".claude/settings.json")
+        }
+    };
+    #[cfg(not(target_os = "windows"))]
     let path = home.join(".claude/settings.json");
+
     if !path.exists() {
         println!("settings.json not found — skipping.");
         return;
@@ -131,9 +162,33 @@ mod tests {
             let cargo_path = cargo_bin.join(bin_name);
             std::fs::write(&cargo_path, b"fake binary").unwrap();
 
+            // On Windows, also test the LOCALAPPDATA candidate path
+            #[cfg(target_os = "windows")]
+            let (tmp_local, localappdata_bin_path) = {
+                let tmp = tempfile::tempdir().unwrap();
+                let programs_dir = tmp.path().join("Programs").join("cship");
+                std::fs::create_dir_all(&programs_dir).unwrap();
+                let bin_path = programs_dir.join("cship.exe");
+                std::fs::write(&bin_path, b"fake binary").unwrap();
+                // Point LOCALAPPDATA to our temp dir so remove_binary finds it
+                unsafe { std::env::set_var("LOCALAPPDATA", tmp.path()) };
+                (tmp, bin_path)
+            };
+
             remove_binary(home);
+
             assert!(!local_path.exists());
             assert!(!cargo_path.exists());
+
+            #[cfg(target_os = "windows")]
+            {
+                assert!(
+                    !localappdata_bin_path.exists(),
+                    "LOCALAPPDATA binary should be removed on Windows"
+                );
+                unsafe { std::env::remove_var("LOCALAPPDATA") };
+                drop(tmp_local);
+            }
         });
     }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -171,6 +171,7 @@ mod tests {
                 let bin_path = programs_dir.join("cship.exe");
                 std::fs::write(&bin_path, b"fake binary").unwrap();
                 // Point LOCALAPPDATA to our temp dir so remove_binary finds it
+                // SAFETY: guarded by HOME_MUTEX; no other threads read LOCALAPPDATA concurrently.
                 unsafe { std::env::set_var("LOCALAPPDATA", tmp.path()) };
                 (tmp, bin_path)
             };
@@ -186,6 +187,7 @@ mod tests {
                     !localappdata_bin_path.exists(),
                     "LOCALAPPDATA binary should be removed on Windows"
                 );
+                // SAFETY: guarded by HOME_MUTEX; no other threads read LOCALAPPDATA concurrently.
                 unsafe { std::env::remove_var("LOCALAPPDATA") };
                 drop(tmp_local);
             }
@@ -223,6 +225,43 @@ mod tests {
                 Some("value"),
                 "other keys should be preserved"
             );
+        });
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_remove_statusline_uses_appdata_on_windows() {
+        with_tempdir(|home| {
+            // Create a temp APPDATA directory with Claude/settings.json
+            let tmp_appdata = tempfile::tempdir().unwrap();
+            let claude_dir = tmp_appdata.path().join("Claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let settings_path = claude_dir.join("settings.json");
+            std::fs::write(
+                &settings_path,
+                r#"{"statusline":"cship","otherKey":"value"}"#,
+            )
+            .unwrap();
+
+            // SAFETY: guarded by HOME_MUTEX; no other threads read APPDATA concurrently.
+            unsafe { std::env::set_var("APPDATA", tmp_appdata.path()) };
+
+            remove_statusline_from_settings(home);
+
+            let content = std::fs::read_to_string(&settings_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert!(
+                parsed.get("statusline").is_none(),
+                "statusline key should be removed from APPDATA path on Windows"
+            );
+            assert_eq!(
+                parsed.get("otherKey").and_then(|v| v.as_str()),
+                Some("value"),
+                "other keys should be preserved"
+            );
+
+            // SAFETY: guarded by HOME_MUTEX; no other threads read APPDATA concurrently.
+            unsafe { std::env::remove_var("APPDATA") };
         });
     }
 
@@ -299,6 +338,7 @@ mod tests {
         // Should print message and return, not panic or touch root paths
         run();
         // Restore to avoid poisoning other tests
+        // SAFETY: guarded by HOME_MUTEX; no other threads read CLAUDE_HOME concurrently.
         unsafe { std::env::remove_var("CLAUDE_HOME") };
     }
 }


### PR DESCRIPTION
## Summary

- Updates the Windows uninstaller to look for the binary in `%LOCALAPPDATA%\Programs\cship\cship.exe`, matching where `install.ps1` places it
- Updates `remove_statusline_from_settings` on Windows to read from `%APPDATA%\Claude\settings.json` (the actual Claude Code settings location on Windows)
- Adds SAFETY comments to all `unsafe { std::env::set_var/remove_var }` calls in tests
- Adds a Windows-only test (`test_remove_statusline_uses_appdata_on_windows`) verifying the correct APPDATA path is used

## Test plan

- [ ] `cargo test` passes on Linux (non-Windows tests unaffected)
- [ ] `cargo test` passes on Windows (new `#[cfg(target_os = "windows")]` tests cover the new paths)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)