### PR TITLE
feat(docs): update PowerShell installer URL to cship.dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Copy installer scripts to public
+        run: |
+          cp install.ps1 docs/public/install.ps1
+          cp install.sh docs/public/install.sh
+
       - name: Build with VitePress
         run: npm run docs:build
         working-directory: docs

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64)
 Run this one-liner in PowerShell (5.1 or later):
 
 ```powershell
-irm https://raw.githubusercontent.com/stephenleo/cship/main/install.ps1 | iex
+irm https://cship.dev/install.ps1 | iex
 ```
 
 Installs to `%LOCALAPPDATA%\Programs\cship\cship.exe`, writes config to `%USERPROFILE%\.config\cship.toml`, and registers the statusline in `%APPDATA%\Claude\settings.json`.
 
-> You can inspect the script before running: [install.ps1](https://raw.githubusercontent.com/stephenleo/cship/main/install.ps1)
+> You can inspect the script before running: [install.ps1](https://cship.dev/install.ps1)
 
 ### 📦 Method 2: cargo install
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .vitepress/dist
 .vitepress/cache
 public/install.sh
+public/install.ps1
 public/examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,12 +51,12 @@ Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64)
 Run this one-liner in PowerShell (5.1 or later):
 
 ```powershell
-irm https://raw.githubusercontent.com/stephenleo/cship/main/install.ps1 | iex
+irm https://cship.dev/install.ps1 | iex
 ```
 
 Installs to `%LOCALAPPDATA%\Programs\cship\cship.exe`, writes config to `%USERPROFILE%\.config\cship.toml`, and registers the statusline in `%APPDATA%\Claude\settings.json`.
 
-> You can inspect the script before running: [install.ps1](https://raw.githubusercontent.com/stephenleo/cship/main/install.ps1)
+> You can inspect the script before running: [install.ps1](https://cship.dev/install.ps1)
 
 ### Cargo Install {#install-cargo}
 


### PR DESCRIPTION
## Summary

- Update the PowerShell one-liner install command in README and docs to use the `cship.dev` URL instead of the raw GitHub URL
- Add `public/install.ps1` to the docs `.gitignore` to prevent the generated installer from being committed
- Update the docs CI workflow to serve the PowerShell installer at `cship.dev/install.ps1`

## Test plan

- [ ] Verify README and docs show the correct `cship.dev`-based PowerShell one-liner
- [ ] Verify docs build passes CI
- [ ] Confirm `public/install.ps1` is excluded from git tracking in the docs directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)