### PR TITLE
feat(release): add CHANGELOG and release notes to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,11 +128,33 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version || github.ref_name }}
       - uses: actions/download-artifact@v4
+      - name: Extract changelog for this release
+        shell: bash
+        env:
+          TAG: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "ERROR: Invalid version format: $TAG" >&2; exit 1
+          fi
+          awk -v ver="[$VERSION]" '
+            p && /^## \[/ { exit }
+            /^## / && index($0, ver) { p=1; next }
+            p { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "See commit history for changes in this release." > /tmp/release-notes.md
+          fi
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           files: cship-*/cship-*
+          body_path: /tmp/release-notes.md
+          generate_release_notes: true
 
   publish:
     name: Publish to crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.2.0] - 2026-03-14
 
 ### Added
-- Configurable TTL for usage limits cache (`ttl` field in `[cship.usage_limits]`)
-
-### Fixed
-- GitHub Actions workflow for external PR secret access
+- Added configurable cache TTL for usage limits — set `ttl` in `[cship.usage_limits]` to control how long API results are cached ([@RedesignedRobot](https://github.com/RedesignedRobot))
 
 ## [1.1.2] - 2026-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `context_window.used_tokens` module ([@0xRaduan](https://github.com/0xRaduan))
 - Added `{remaining}` placeholder to usage limits format strings ([@tkm3d1a](https://github.com/tkm3d1a))
 - Added ability to read `rate_limits` from Claude Code stdin before falling back to the OAuth API ([@0xRaduan](https://github.com/0xRaduan))
-- Added ability to hide individual usage limit periods via empty format strings
 
 ### Fixed
 - Fixed context bar showing blank at the start of a fresh session — now renders an empty 0% bar
@@ -24,8 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.3.0] - 2026-03-14
 
 ### Added
-- `$starship_prompt` token support in format strings with `STARSHIP_SHELL` fix
-- Full Starship prompt showcase example in docs
+- Added `$starship_prompt` token to format strings — embed your full Starship prompt inside a cship layout
 
 ## [1.2.0] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.4.0] - 2026-03-28
 
 ### Added
-- Windows support: x86_64 and aarch64-pc-windows-msvc release targets
-- Windows installer (`install.ps1`) with WOW64 arch detection and JSON depth hardening
-- Windows uninstaller aligned with installer paths
-- Windows documentation in README and docs site
+- Added Windows support — native builds for x86_64 and arm64, PowerShell installer/uninstaller, and Windows docs ([@tkm3d1a](https://github.com/tkm3d1a))
+- Added `context_window.used_tokens` module ([@0xRaduan](https://github.com/0xRaduan))
+- Added `{remaining}` placeholder to usage limits format strings ([@tkm3d1a](https://github.com/tkm3d1a))
+- Added ability to read `rate_limits` from Claude Code stdin before falling back to the OAuth API ([@0xRaduan](https://github.com/0xRaduan))
+- Added ability to hide individual usage limit periods via empty format strings
+
+### Fixed
+- Fixed context bar showing blank at the start of a fresh session — now renders an empty 0% bar
+- Fixed token counts being truncated instead of rounded in display
+- Fixed crash when stdin contains partial rate_limits data
 
 ### Changed
-- PowerShell installer one-liner URL updated to `cship.dev` domain
-- CI test `test_remove_statusline_present` guarded as non-Windows only
+- Updated PowerShell installer URL to `cship.dev` domain
 
 ## [1.3.0] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [1.4.0] - 2026-03-28
+
+### Added
+- Windows support: x86_64 and aarch64-pc-windows-msvc release targets
+- Windows installer (`install.ps1`) with WOW64 arch detection and JSON depth hardening
+- Windows uninstaller aligned with installer paths
+- Windows documentation in README and docs site
+
+### Changed
+- PowerShell installer one-liner URL updated to `cship.dev` domain
+- CI test `test_remove_statusline_present` guarded as non-Windows only
+
+## [1.3.0] - 2026-03-14
+
+### Added
+- `$starship_prompt` token support in format strings with `STARSHIP_SHELL` fix
+- Full Starship prompt showcase example in docs
+
+## [1.2.0] - 2026-03-14
+
+### Added
+- Configurable TTL for usage limits cache (`ttl` field in `[cship.usage_limits]`)
+
+### Fixed
+- GitHub Actions workflow for external PR secret access
+
+## [1.1.2] - 2026-03-13
+
+### Added
+- VitePress documentation site deployed to GitHub Pages (`cship.dev`)
+- Hero GIF and annotated hero image in README
+
+## [1.1.1] - 2026-03-12
+
+### Fixed
+- Minor documentation and workflow fixes
+
+## [1.1.0] - 2026-03-11
+
+### Added
+- `warn_threshold` / `critical_threshold` support on `cost` subfields
+- `warn_threshold` / `critical_threshold` support on `context_window` subfields
+- `invert_threshold` on `context_window.remaining_percentage` to fix inverted threshold semantics
+- GitHub badges in README
+
+## [1.0.0] - 2026-03-09
+
+### Added
+- Initial stable release
+- Native modules: `model`, `cost`, `context_bar`, `context_window`, `vim`, `agent`, `cwd`, `session_id`, `version`, `output_style`, `workspace`, `usage_limits`
+- Starship passthrough with 5s session-hashed file cache
+- Per-module `format` strings (Starship-compatible syntax)
+- `cship explain` subcommand for self-service debug
+- `cship uninstall` subcommand
+- `curl | bash` installer with Starship and libsecret-tools detection
+- GitHub Actions release pipeline (macOS arm64/x86_64, Linux musl arm64/x86_64)
+- crates.io publication
+
+## [0.0.1-rc1] - 2026-03-08
+
+### Added
+- First release candidate


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` with entries for all releases from v0.0.1-rc1 through v1.4.0
- Updates `.github/workflows/release.yml` so every GitHub release body shows the curated CHANGELOG section on top, followed by auto-generated PR/commit notes below
- Release notes are extracted from `CHANGELOG.md` by version tag using `awk`; falls back to a generic message if no entry exists

## How it works
1. The `release` job checks out the repo at the release tag to access `CHANGELOG.md`
2. An `awk` script extracts the section matching the current version (e.g. `## [1.4.0]`)
3. `softprops/action-gh-release@v2` renders the extracted notes as the release body, then appends GitHub's auto-generated contributor/PR list below

## Test plan
- [ ] Verify `CHANGELOG.md` renders correctly on GitHub
- [ ] Trigger a test release and confirm the release body shows CHANGELOG content above auto-generated notes
- [ ] Confirm fallback message appears for a version with no CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)