### PR TITLE
chore(release): bump version to v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.4.0] - 2026-03-28
+## [1.4.1] - 2026-03-28
 
 ### Added
 - Added Windows support — native builds for x86_64 and arm64, PowerShell installer/uninstaller, and Windows docs ([@tkm3d1a](https://github.com/tkm3d1a))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cship"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "cship"
-version       = "1.4.0"
+version       = "1.4.1"
 edition       = "2024"
 description   = "Beautiful, Blazing-fast, Customizable Claude Code Statusline"
 license       = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from `1.4.0` to `1.4.1` to allow publishing to crates.io

crates.io does not permit re-publishing a yanked version number. The Windows installer fixes shipped in the previous PR (#144) require a new patch release.

## Test plan

- [ ] Merge and tag `v1.4.1`
- [ ] CI builds and publishes to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)