### PR TITLE
feat(peak_usage): add peak-time indicator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Everything in the [Claude Code status line documentation](https://code.claude.co
 | `$cship.context_window` | Context window tokens (used/total) |
 | `$cship.context_window.used_tokens` | Real token count in context with percentage (e.g. `8%(79k/1000k)`) |
 | `$cship.usage_limits` | API usage limits (5hr / 7-day) |
+| `$cship.peak_usage` | Peak-time indicator (US Pacific business hours) |
 | `$cship.agent` | Sub-agent name |
 | `$cship.session` | Session identity info |
 | `$cship.workspace` | Workspace/project directory |
@@ -199,7 +200,7 @@ critical_style     = "bold red"
 
 ### 3. 💰 Cost Guardian
 
-Shows cost, lines changed, and rolling API usage limits all at once. Colour escalates as budgets fill.
+Shows cost, lines changed, rolling API usage limits, and a peak-time indicator. Colour escalates as budgets fill.
 
 <img src="./docs/examples/05.png" alt="Cost guardian cship statusline example" width="600">
 
@@ -210,7 +211,7 @@ Shows cost, lines changed, and rolling API usage limits all at once. Colour esca
 [cship]
 lines = [
   "$cship.model $cship.cost +$cship.cost.total_lines_added -$cship.cost.total_lines_removed",
-  "$cship.context_bar $cship.usage_limits",
+  "$cship.context_bar $cship.usage_limits $cship.peak_usage",
 ]
 
 [cship.model]
@@ -238,6 +239,9 @@ warn_threshold     = 70.0
 warn_style         = "bold yellow"
 critical_threshold = 90.0
 critical_style     = "bold red"
+
+[cship.peak_usage]
+style = "bold yellow"
 ```
 
 </details>

--- a/cship.toml
+++ b/cship.toml
@@ -1,7 +1,7 @@
 [cship]
 lines = [
   "$starship_prompt",
-  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits"
+  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage"
 ]
 
 [cship.model]
@@ -34,3 +34,7 @@ warn_threshold     = 60.0
 warn_style         = "fg:#e0af68"
 critical_threshold = 80.0
 critical_style     = "bold fg:#f7768e"
+
+[cship.peak_usage]
+symbol = "⏰ "
+style  = "fg:#e0af68"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,37 @@ Setting both formats to `""` effectively hides the entire module.
 
 ---
 
+## `[cship.peak_usage]` — Peak-Time Indicator
+
+Shows when Anthropic's peak-time rate limiting is likely active, based on current time relative to US Pacific business hours. Returns nothing outside peak hours so the indicator disappears entirely.
+
+The check is purely time-based (Mon–Fri, default 07:00–17:00 Pacific) — no network calls.
+
+**Token:** `$cship.peak_usage`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `disabled` | `bool` | `false` | Hide this module |
+| `style` | `string` | — | ANSI style |
+| `symbol` | `string` | `"⏰ "` | Prefix symbol |
+| `format` | `string` | `"[$symbol$value]($style)"` | Format string; `$value` = `Peak` |
+| `start_hour` | `integer` | `7` | Start of peak window in US Pacific time (0–23) |
+| `end_hour` | `integer` | `17` | End of peak window in US Pacific time, exclusive (0–24). Use `24` to mean through end of day |
+
+**Variables:** `$value` (`Peak`), `$symbol`, `$style`
+
+US Pacific DST is handled automatically — PDT (UTC−7) from the second Sunday of March to the first Sunday of November, PST (UTC−8) otherwise.
+
+```toml
+[cship.peak_usage]
+symbol     = "⏰ "
+style      = "fg:#e0af68"
+start_hour = 7
+end_hour   = 17
+```
+
+---
+
 ## `[cship.starship_prompt]` — Full Starship Prompt
 
 Renders your entire Starship-configured prompt in a single call. Unlike per-module passthrough (e.g., `$directory`, `$git_branch`), this token invokes `starship prompt` to produce the complete rendered prompt with all configured modules.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,6 +64,24 @@ The CShip `usage_limits` module fetches data from the Anthropic API using your C
 
 ---
 
+## How does the peak-time indicator handle time zones and DST?
+
+The `peak_usage` module checks whether the current time falls within the configured peak window in **US Pacific time**. It computes the UTC→Pacific offset internally — PDT (UTC−7) from the second Sunday of March through the first Sunday of November, PST (UTC−8) the rest of the year.
+
+There are no dependencies on system locale or `TZ` environment variable; the DST boundaries are calculated from the UTC date using Tomohiko Sakamoto's day-of-week algorithm.
+
+**Defaults:** Mon–Fri, 07:00–17:00 Pacific. To customise:
+
+```toml
+[cship.peak_usage]
+start_hour = 9   # 9 AM Pacific
+end_hour   = 18  # 6 PM Pacific (exclusive)
+```
+
+Set `end_hour = 24` to mean "through end of day". Weekends always return nothing.
+
+---
+
 ## Why is my cost or context not updating?
 
 **Cost and context window** data comes from Claude Code's JSON feed, which is updated on every statusline render (every time Claude Code calls `cship`). If these values appear stuck, check:

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -69,7 +69,7 @@ critical_style     = "bold red"
 
 ## 3. Cost Guardian
 
-Shows cost, lines changed, and rolling API usage limits all at once. Colour escalates as budgets fill.
+Shows cost, lines changed, rolling API usage limits, and a peak-time indicator. Colour escalates as budgets fill.
 
 ![Cost guardian cship statusline](./examples/05.png)
 
@@ -77,7 +77,7 @@ Shows cost, lines changed, and rolling API usage limits all at once. Colour esca
 [cship]
 lines = [
   "$cship.model $cship.cost +$cship.cost.total_lines_added -$cship.cost.total_lines_removed",
-  "$cship.context_bar $cship.usage_limits",
+  "$cship.context_bar $cship.usage_limits $cship.peak_usage",
 ]
 
 [cship.model]
@@ -105,6 +105,9 @@ warn_threshold     = 70.0
 warn_style         = "bold yellow"
 critical_threshold = 90.0
 critical_style     = "bold red"
+
+[cship.peak_usage]
+style = "bold yellow"
 ```
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,7 +278,8 @@ pub struct PeakUsageConfig {
     pub format: Option<String>,
     /// Start of peak window in US Pacific time (0–23). Default: 7.
     pub start_hour: Option<u32>,
-    /// End of peak window in US Pacific time (0–23). Default: 17.
+    /// End of peak window in US Pacific time, exclusive (0–24). Default: 17.
+    /// Use 24 to mean "through end of day" (e.g., `start_hour = 0, end_hour = 24` = all day).
     pub end_hour: Option<u32>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct CshipConfig {
     pub session: Option<SessionConfig>,
     pub workspace: Option<WorkspaceConfig>,
     pub usage_limits: Option<UsageLimitsConfig>,
+    pub peak_usage: Option<PeakUsageConfig>,
     pub starship_prompt: Option<StarshipPromptConfig>,
 }
 
@@ -264,6 +265,21 @@ pub struct UsageLimitsConfig {
     pub five_hour_format: Option<String>,
     pub seven_day_format: Option<String>,
     pub separator: Option<String>,
+}
+
+/// Configuration for `[cship.peak_usage]` — peak-time indicator.
+/// Shows when Anthropic's peak-time rate limiting is likely active
+/// based on current time relative to US Pacific business hours.
+#[derive(Debug, Deserialize, Default)]
+pub struct PeakUsageConfig {
+    pub disabled: Option<bool>,
+    pub symbol: Option<String>,
+    pub style: Option<String>,
+    pub format: Option<String>,
+    /// Start of peak window in US Pacific time (0–23). Default: 7.
+    pub start_hour: Option<u32>,
+    /// End of peak window in US Pacific time (0–23). Default: 17.
+    pub end_hour: Option<u32>,
 }
 
 /// Configuration for `[cship.starship_prompt]` — renders full starship prompt as a token.

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,6 +3,7 @@ pub mod context_bar;
 pub mod context_window;
 pub mod cost;
 pub mod model;
+pub mod peak_usage;
 pub mod session;
 pub mod usage_limits;
 pub mod vim;
@@ -44,6 +45,7 @@ pub const ALL_NATIVE_MODULES: &[&str] = &[
     "cship.workspace.current_dir",
     "cship.workspace.project_dir",
     "cship.usage_limits",
+    "cship.peak_usage",
 ];
 
 /// Static dispatch registry — the ONLY file modified when adding a new native module.
@@ -109,6 +111,8 @@ pub fn render_module(
         "cship.workspace.project_dir" => workspace::render_project_dir(ctx, cfg),
         // Usage limits module — non-blocking thread dispatch for live API data
         "cship.usage_limits" => usage_limits::render(ctx, cfg),
+        // Peak usage indicator — time-based peak-hour check
+        "cship.peak_usage" => peak_usage::render(ctx, cfg),
         other => {
             tracing::warn!("cship: unknown native module '{other}' — skipping");
             None

--- a/src/modules/peak_usage.rs
+++ b/src/modules/peak_usage.rs
@@ -50,11 +50,10 @@ pub fn render(_ctx: &Context, cfg: &CshipConfig) -> Option<String> {
 
 /// Returns `true` when `utc_epoch_secs` falls within the configured peak window
 /// (default: Mon–Fri 07:00–17:00 US Pacific).
-fn is_peak_time(
-    utc_epoch_secs: u64,
-    pk_cfg: Option<&crate::config::PeakUsageConfig>,
-) -> bool {
-    let start = pk_cfg.and_then(|c| c.start_hour).unwrap_or(DEFAULT_START_HOUR);
+fn is_peak_time(utc_epoch_secs: u64, pk_cfg: Option<&crate::config::PeakUsageConfig>) -> bool {
+    let start = pk_cfg
+        .and_then(|c| c.start_hour)
+        .unwrap_or(DEFAULT_START_HOUR);
     let end = pk_cfg.and_then(|c| c.end_hour).unwrap_or(DEFAULT_END_HOUR);
 
     if start >= end {
@@ -64,9 +63,10 @@ fn is_peak_time(
         );
         return false;
     }
-    if start > 23 || end > 23 {
+    if start > 23 || end > 24 {
         tracing::warn!(
-            "cship.peak_usage: start_hour ({start}) or end_hour ({end}) outside 0–23 range"
+            "cship.peak_usage: start_hour ({start}) or end_hour ({end}) out of range \
+             (start: 0–23, end: 0–24)"
         );
         return false;
     }
@@ -100,7 +100,7 @@ fn pacific_offset_secs(utc_epoch_secs: u64) -> i64 {
     let november_first_sunday = nth_sunday_of_month(year, 11, 1);
 
     let is_pdt = match month {
-        4..=10 => true, // Apr–Oct: always PDT
+        4..=10 => true,      // Apr–Oct: always PDT
         1..=2 | 12 => false, // Jan–Feb, Dec: always PST
         3 => {
             // March: PDT after second Sunday 10:00 UTC
@@ -123,8 +123,7 @@ fn utc_epoch_to_ymd_h(secs: u64) -> (i32, u32, u32, u32) {
     let z = (secs / SECS_PER_DAY) as i64 + 719468;
     let era = if z >= 0 { z } else { z - 146096 } / 146097;
     let doe = (z - era * 146097) as u64; // day of era [0, 146096]
-    let yoe =
-        (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
     let y = yoe as i64 + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
     let mp = (5 * doy + 2) / 153;
@@ -144,7 +143,11 @@ fn nth_sunday_of_month(year: i32, month: u32, n: u32) -> u32 {
     // Day of week for the 1st of the month (0=Sun, 1=Mon, ..., 6=Sat)
     let dow_first = day_of_week(year, month, 1);
     // Days until first Sunday
-    let first_sunday = if dow_first == 0 { 1 } else { 1 + (7 - dow_first) };
+    let first_sunday = if dow_first == 0 {
+        1
+    } else {
+        1 + (7 - dow_first)
+    };
     // Nth Sunday
     first_sunday + 7 * (n - 1)
 }
@@ -156,8 +159,8 @@ fn day_of_week(mut year: i32, month: u32, day: u32) -> u32 {
     if month < 3 {
         year -= 1;
     }
-    ((year + year / 4 - year / 100 + year / 400 + T[(month - 1) as usize] as i32 + day as i32)
-        % 7) as u32
+    ((year + year / 4 - year / 100 + year / 400 + T[(month - 1) as usize] as i32 + day as i32) % 7)
+        as u32
 }
 
 #[cfg(test)]
@@ -179,8 +182,16 @@ mod tests {
 
     /// Days from 1970-01-01 to a civil date (Howard Hinnant algorithm).
     fn civil_days_from_epoch(year: i32, month: u32, day: u32) -> i64 {
-        let y = if month <= 2 { year as i64 - 1 } else { year as i64 };
-        let m = if month <= 2 { month as i64 + 9 } else { month as i64 - 3 };
+        let y = if month <= 2 {
+            year as i64 - 1
+        } else {
+            year as i64
+        };
+        let m = if month <= 2 {
+            month as i64 + 9
+        } else {
+            month as i64 - 3
+        };
         let era = if y >= 0 { y } else { y - 399 } / 400;
         let yoe = (y - era * 400) as u64;
         let doy = (153 * m as u64 + 2) / 5 + day as u64 - 1;
@@ -372,6 +383,30 @@ mod tests {
         };
         let ts = pacific_to_utc(2026, 4, 8, 10);
         assert!(!is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_end_hour_24_covers_full_day() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(0),
+            end_hour: Some(24),
+            ..Default::default()
+        };
+        // Hour 23 should be included
+        let ts = pacific_to_utc(2026, 4, 8, 23);
+        assert!(is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_end_hour_24_is_valid() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(7),
+            end_hour: Some(24),
+            ..Default::default()
+        };
+        // Hour 23 within 7–24 window
+        let ts = pacific_to_utc(2026, 4, 8, 23);
+        assert!(is_peak_time(ts, Some(&pk_cfg)));
     }
 
     #[test]

--- a/src/modules/peak_usage.rs
+++ b/src/modules/peak_usage.rs
@@ -1,0 +1,383 @@
+//! Peak-time usage indicator — shows when Anthropic's peak-time rate limiting
+//! is likely active, based on current time relative to US Pacific business hours.
+//!
+//! Pure time-based check with no network calls. US Pacific DST boundaries are
+//! computed via Tomohiko Sakamoto's day-of-week algorithm.
+
+use crate::config::CshipConfig;
+use crate::context::Context;
+
+const DEFAULT_START_HOUR: u32 = 7;
+const DEFAULT_END_HOUR: u32 = 17;
+const DEFAULT_SYMBOL: &str = "⏰ ";
+const PEAK_LABEL: &str = "Peak";
+
+/// Seconds per day / hour / minute for UTC → Pacific conversion.
+const SECS_PER_DAY: u64 = 86400;
+const SECS_PER_HOUR: u64 = 3600;
+
+/// Render `$cship.peak_usage` — returns styled indicator during peak hours, `None` otherwise.
+pub fn render(_ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let pk_cfg = cfg.peak_usage.as_ref();
+
+    // Disabled → silent None
+    if pk_cfg.and_then(|c| c.disabled) == Some(true) {
+        return None;
+    }
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+
+    if !is_peak_time(now_secs, pk_cfg) {
+        return None;
+    }
+
+    let symbol = pk_cfg
+        .and_then(|c| c.symbol.as_deref())
+        .unwrap_or(DEFAULT_SYMBOL);
+    let style = pk_cfg.and_then(|c| c.style.as_deref());
+
+    // Format string takes priority if configured
+    if let Some(fmt) = pk_cfg.and_then(|c| c.format.as_deref()) {
+        return crate::format::apply_module_format(fmt, Some(PEAK_LABEL), Some(symbol), style);
+    }
+
+    let content = format!("{symbol}{PEAK_LABEL}");
+    Some(crate::ansi::apply_style(&content, style))
+}
+
+/// Returns `true` when `utc_epoch_secs` falls within the configured peak window
+/// (default: Mon–Fri 07:00–17:00 US Pacific).
+fn is_peak_time(
+    utc_epoch_secs: u64,
+    pk_cfg: Option<&crate::config::PeakUsageConfig>,
+) -> bool {
+    let start = pk_cfg.and_then(|c| c.start_hour).unwrap_or(DEFAULT_START_HOUR);
+    let end = pk_cfg.and_then(|c| c.end_hour).unwrap_or(DEFAULT_END_HOUR);
+
+    if start >= end {
+        tracing::warn!(
+            "cship.peak_usage: start_hour ({start}) >= end_hour ({end}); \
+             overnight wrap-around is not supported — module will never activate"
+        );
+        return false;
+    }
+    if start > 23 || end > 23 {
+        tracing::warn!(
+            "cship.peak_usage: start_hour ({start}) or end_hour ({end}) outside 0–23 range"
+        );
+        return false;
+    }
+
+    let offset_secs = pacific_offset_secs(utc_epoch_secs);
+    // Apply signed offset to UTC epoch. Pacific is always behind UTC, so offset is negative.
+    let pacific_secs = (utc_epoch_secs as i64 + offset_secs) as u64;
+
+    let day_secs = pacific_secs % SECS_PER_DAY;
+    let hour = (day_secs / SECS_PER_HOUR) as u32;
+
+    // Compute weekday from Pacific date (0=Sun, 1=Mon, ..., 6=Sat)
+    let days_since_epoch = pacific_secs / SECS_PER_DAY;
+    // 1970-01-01 was Thursday (4)
+    let weekday = ((days_since_epoch + 4) % 7) as u32;
+
+    let is_weekday = (1..=5).contains(&weekday); // Mon=1 .. Fri=5
+    is_weekday && hour >= start && hour < end
+}
+
+/// Returns the UTC offset for US Pacific time in seconds.
+/// PDT (UTC−7) from second Sunday of March 10:00 UTC to first Sunday of November 09:00 UTC.
+/// PST (UTC−8) otherwise.
+fn pacific_offset_secs(utc_epoch_secs: u64) -> i64 {
+    let (year, month, day, hour) = utc_epoch_to_ymd_h(utc_epoch_secs);
+
+    // DST transition boundaries (in UTC):
+    // Spring forward: second Sunday of March at 2:00 AM PST = 10:00 UTC
+    let march_second_sunday = nth_sunday_of_month(year, 3, 2);
+    // Fall back: first Sunday of November at 2:00 AM PDT = 09:00 UTC
+    let november_first_sunday = nth_sunday_of_month(year, 11, 1);
+
+    let is_pdt = match month {
+        4..=10 => true, // Apr–Oct: always PDT
+        1..=2 | 12 => false, // Jan–Feb, Dec: always PST
+        3 => {
+            // March: PDT after second Sunday 10:00 UTC
+            day > march_second_sunday || (day == march_second_sunday && hour >= 10)
+        }
+        11 => {
+            // November: PST after first Sunday 09:00 UTC
+            day < november_first_sunday || (day == november_first_sunday && hour < 9)
+        }
+        _ => false,
+    };
+
+    if is_pdt { -7 * 3600 } else { -8 * 3600 }
+}
+
+/// Convert UTC epoch seconds to (year, month, day, hour).
+fn utc_epoch_to_ymd_h(secs: u64) -> (i32, u32, u32, u32) {
+    // Civil date from days since epoch using the algorithm from
+    // Howard Hinnant's chrono-Compatible Low-Level Date Algorithms.
+    let z = (secs / SECS_PER_DAY) as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64; // day of era [0, 146096]
+    let yoe =
+        (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    let day_secs = secs % SECS_PER_DAY;
+    let hour = (day_secs / SECS_PER_HOUR) as u32;
+
+    (y as i32, m as u32, d as u32, hour)
+}
+
+/// Returns the day-of-month for the Nth Sunday of a given month/year.
+/// Uses Tomohiko Sakamoto's day-of-week algorithm.
+fn nth_sunday_of_month(year: i32, month: u32, n: u32) -> u32 {
+    // Day of week for the 1st of the month (0=Sun, 1=Mon, ..., 6=Sat)
+    let dow_first = day_of_week(year, month, 1);
+    // Days until first Sunday
+    let first_sunday = if dow_first == 0 { 1 } else { 1 + (7 - dow_first) };
+    // Nth Sunday
+    first_sunday + 7 * (n - 1)
+}
+
+/// Tomohiko Sakamoto's day-of-week algorithm.
+/// Returns 0=Sun, 1=Mon, ..., 6=Sat.
+fn day_of_week(mut year: i32, month: u32, day: u32) -> u32 {
+    static T: [u32; 12] = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
+    if month < 3 {
+        year -= 1;
+    }
+    ((year + year / 4 - year / 100 + year / 400 + T[(month - 1) as usize] as i32 + day as i32)
+        % 7) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CshipConfig, PeakUsageConfig};
+    use crate::context::Context;
+
+    /// Helper: build a UTC epoch for a specific Pacific date/time,
+    /// accounting for the DST offset on that date.
+    fn pacific_to_utc(year: i32, month: u32, day: u32, hour: u32) -> u64 {
+        let days = civil_days_from_epoch(year, month, day);
+        let utc_approx = (days as u64) * SECS_PER_DAY + (hour as u64) * SECS_PER_HOUR;
+        // Determine offset at this approximate UTC time, then adjust
+        let offset = pacific_offset_secs(utc_approx);
+        // Pacific = UTC + offset, so UTC = Pacific - offset
+        (utc_approx as i64 - offset) as u64
+    }
+
+    /// Days from 1970-01-01 to a civil date (Howard Hinnant algorithm).
+    fn civil_days_from_epoch(year: i32, month: u32, day: u32) -> i64 {
+        let y = if month <= 2 { year as i64 - 1 } else { year as i64 };
+        let m = if month <= 2 { month as i64 + 9 } else { month as i64 - 3 };
+        let era = if y >= 0 { y } else { y - 399 } / 400;
+        let yoe = (y - era * 400) as u64;
+        let doy = (153 * m as u64 + 2) / 5 + day as u64 - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146097 + doe as i64 - 719468
+    }
+
+    #[test]
+    fn test_peak_active_weekday_morning() {
+        // Wednesday 2026-04-08 10:00 PT (PDT, so UTC-7)
+        let ts = pacific_to_utc(2026, 4, 8, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_off_peak_weekday_evening() {
+        // Wednesday 2026-04-08 20:00 PT
+        let ts = pacific_to_utc(2026, 4, 8, 20);
+        assert!(!is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_off_peak_weekend() {
+        // Saturday 2026-04-11 12:00 PT
+        let ts = pacific_to_utc(2026, 4, 11, 12);
+        assert!(!is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_peak_boundary_start() {
+        // Wednesday 2026-04-08 07:00 PT — exactly at start, should be peak
+        let ts = pacific_to_utc(2026, 4, 8, 7);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_peak_boundary_end() {
+        // Wednesday 2026-04-08 17:00 PT — at end boundary, should NOT be peak (< 17)
+        let ts = pacific_to_utc(2026, 4, 8, 17);
+        assert!(!is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_peak_boundary_just_before_end() {
+        // Wednesday 2026-04-08 16:59 PT — just before end, should be peak
+        let ts = pacific_to_utc(2026, 4, 8, 16);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_custom_hours() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(9),
+            end_hour: Some(18),
+            ..Default::default()
+        };
+        // Wednesday 2026-04-08 08:00 PT — before custom start
+        let ts = pacific_to_utc(2026, 4, 8, 8);
+        assert!(!is_peak_time(ts, Some(&pk_cfg)));
+        // Wednesday 2026-04-08 17:30 PT — within custom window
+        let ts = pacific_to_utc(2026, 4, 8, 17);
+        assert!(is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_dst_spring_forward_march() {
+        // 2026 DST spring forward: second Sunday of March = March 8
+        // March 9 (Monday) should be PDT (UTC-7)
+        // 10:00 PT on March 9 = 17:00 UTC
+        let ts = pacific_to_utc(2026, 3, 9, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_dst_fall_back_november() {
+        // 2026 DST fall back: first Sunday of November = November 1
+        // November 2 (Monday) should be PST (UTC-8)
+        // 10:00 PT on Nov 2 = 18:00 UTC
+        let ts = pacific_to_utc(2026, 11, 2, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_pst_january() {
+        // January is always PST (UTC-8)
+        // Wednesday 2026-01-07 10:00 PT = 18:00 UTC
+        let ts = pacific_to_utc(2026, 1, 7, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_disabled_returns_none() {
+        let cfg = CshipConfig {
+            peak_usage: Some(PeakUsageConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let ctx = Context::default();
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_render_with_custom_symbol() {
+        // We can't easily control SystemTime::now() in render(), so test the
+        // format logic via a direct is_peak_time check + verify the format path.
+        let pk_cfg = PeakUsageConfig {
+            symbol: Some("🔥 ".to_string()),
+            ..Default::default()
+        };
+        let symbol = pk_cfg.symbol.as_deref().unwrap_or(DEFAULT_SYMBOL);
+        let content = format!("{symbol}{PEAK_LABEL}");
+        assert_eq!(content, "🔥 Peak");
+    }
+
+    #[test]
+    fn test_day_of_week_known_dates() {
+        // 2026-04-08 is a Wednesday (3)
+        assert_eq!(day_of_week(2026, 4, 8), 3);
+        // 2026-04-11 is a Saturday (6)
+        assert_eq!(day_of_week(2026, 4, 11), 6);
+        // 2026-04-12 is a Sunday (0)
+        assert_eq!(day_of_week(2026, 4, 12), 0);
+        // 1970-01-01 was a Thursday (4)
+        assert_eq!(day_of_week(1970, 1, 1), 4);
+    }
+
+    #[test]
+    fn test_nth_sunday_of_month() {
+        // Second Sunday of March 2026 = March 8
+        assert_eq!(nth_sunday_of_month(2026, 3, 2), 8);
+        // First Sunday of November 2026 = November 1
+        assert_eq!(nth_sunday_of_month(2026, 11, 1), 1);
+    }
+
+    #[test]
+    fn test_utc_epoch_to_ymd_h_known_date() {
+        // 2026-04-08 00:00:00 UTC
+        // Days from epoch: use civil_days_from_epoch helper
+        let days = civil_days_from_epoch(2026, 4, 8);
+        let secs = (days as u64) * SECS_PER_DAY + 14 * SECS_PER_HOUR; // 14:00 UTC
+        let (y, m, d, h) = utc_epoch_to_ymd_h(secs);
+        assert_eq!((y, m, d, h), (2026, 4, 8, 14));
+    }
+
+    #[test]
+    fn test_monday_is_peak() {
+        // Monday 2026-04-06 10:00 PT
+        let ts = pacific_to_utc(2026, 4, 6, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_friday_is_peak() {
+        // Friday 2026-04-10 10:00 PT
+        let ts = pacific_to_utc(2026, 4, 10, 10);
+        assert!(is_peak_time(ts, None));
+    }
+
+    #[test]
+    fn test_start_ge_end_returns_false() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(18),
+            end_hour: Some(6),
+            ..Default::default()
+        };
+        let ts = pacific_to_utc(2026, 4, 8, 10);
+        assert!(!is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_start_equals_end_returns_false() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(10),
+            end_hour: Some(10),
+            ..Default::default()
+        };
+        let ts = pacific_to_utc(2026, 4, 8, 10);
+        assert!(!is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_hour_out_of_range_returns_false() {
+        let pk_cfg = PeakUsageConfig {
+            start_hour: Some(25),
+            end_hour: Some(30),
+            ..Default::default()
+        };
+        let ts = pacific_to_utc(2026, 4, 8, 10);
+        assert!(!is_peak_time(ts, Some(&pk_cfg)));
+    }
+
+    #[test]
+    fn test_sunday_is_not_peak() {
+        // Sunday 2026-04-12 10:00 PT
+        let ts = pacific_to_utc(2026, 4, 12, 10);
+        assert!(!is_peak_time(ts, None));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #146.

- Adds `cship.peak_usage` module that shows `⏰ Peak` when Anthropic's peak-time rate limiting is likely active (Mon–Fri 07:00–17:00 US Pacific by default)
- Zero new dependencies: uses Howard Hinnant's civil date algorithm and Tomohiko Sakamoto's day-of-week algorithm for DST-aware UTC→Pacific conversion
- Configurable `start_hour`/`end_hour` with validation warnings for invalid ranges
- 23 unit tests covering peak/off-peak, DST transitions, custom hours, weekday boundaries, and config validation

## Configuration

```toml
[cship.peak_usage]
symbol = "⏰ "
style  = "fg:#e0af68"
# start_hour = 7   # optional, default
# end_hour = 17    # optional, default (use 24 for "through end of day")
```

## Test plan
- [x] `cargo test --lib modules::peak_usage` — 23 tests pass
- [x] `cargo test` — full suite (343 unit + 66 integration) passes
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] Manual test: verified indicator appears in live statusline with `start_hour=0, end_hour=24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)