### PR TITLE
fix: resolve clippy warnings in explain and cli tests

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -333,8 +333,10 @@ mod tests {
 
     #[test]
     fn test_config_section_for_model_with_config() {
-        let mut cfg = CshipConfig::default();
-        cfg.model = Some(crate::config::ModelConfig::default());
+        let cfg = CshipConfig {
+            model: Some(crate::config::ModelConfig::default()),
+            ..Default::default()
+        };
         assert_eq!(config_section_for("cship.model", &cfg), "[cship.model]");
     }
 
@@ -438,11 +440,13 @@ mod tests {
 
     #[test]
     fn test_error_hint_for_disabled_module_returns_disabled_text() {
-        let mut cfg = CshipConfig::default();
-        cfg.model = Some(ModelConfig {
-            disabled: Some(true),
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         let ctx = Context {
             model: Some(Model {
                 display_name: Some("Sonnet".to_string()),
@@ -466,11 +470,13 @@ mod tests {
 
     #[test]
     fn test_is_disabled_returns_true_for_disabled_model() {
-        let mut cfg = CshipConfig::default();
-        cfg.model = Some(ModelConfig {
-            disabled: Some(true),
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         assert!(
             is_disabled("cship.model", &cfg),
             "is_disabled should return true when model.disabled = Some(true)"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -372,7 +372,7 @@ fn test_context_window_subfields_render_correctly() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     // Output format: "8 92 200000\n" — verify each value appears as a space-delimited token
-    let tokens: Vec<&str> = stdout.trim().split_whitespace().collect();
+    let tokens: Vec<&str> = stdout.split_whitespace().collect();
     assert_eq!(
         tokens.len(),
         3,
@@ -445,7 +445,7 @@ fn test_context_window_total_tokens_render_correctly() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let tokens: Vec<&str> = stdout.trim().split_whitespace().collect();
+    let tokens: Vec<&str> = stdout.split_whitespace().collect();
     assert_eq!(tokens.len(), 2, "expected 2 tokens: {stdout:?}");
     assert_eq!(
         tokens[0], "15234",


### PR DESCRIPTION
## Summary

- **`field_reassign_with_default`** in `explain.rs` tests: use struct initializer syntax instead of creating a `Default` and reassigning fields
- **`trim_split_whitespace`** in `cli.rs` tests: remove redundant `.trim()` before `.split_whitespace()` (which already trims)

These are pre-existing warnings surfaced by Clippy 1.94. No functional changes.

> I don't want to overwhelm — just noticed these while working on something else and figured a quick cleanup PR would be welcome.

## Test plan

- [x] `cargo fmt` — passes
- [x] `cargo clippy -- -D warnings` — passes (these were the only two warnings)
- [x] `cargo test` — all tests pass