### PR TITLE
feat(usage_limits): add extra usage, per-model rendering, pace tracking, and sub-field renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Everything in the [Claude Code status line documentation](https://code.claude.co
 | `$cship.context_bar` | Visual progress bar of context window usage |
 | `$cship.context_window` | Context window tokens (used/total) |
 | `$cship.context_window.used_tokens` | Real token count in context with percentage (e.g. `8%(79k/1000k)`) |
-| `$cship.usage_limits` | API usage limits (5hr / 7-day) |
+| `$cship.usage_limits` | API usage limits (5hr / 7-day, plus per-model and extra-usage when available) |
+| `$cship.usage_limits.per_model` | 7-day per-model breakdown (opus / sonnet / cowork / oauth) |
+| `$cship.usage_limits.extra_usage` | Extra-credits section with `{active}` indicator |
 | `$cship.peak_usage` | Peak-time indicator (US Pacific business hours) |
 | `$cship.agent` | Sub-agent name |
 | `$cship.session` | Session identity info |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,39 +304,91 @@ Displays 5-hour and 7-day API utilization percentages with time-to-reset.
 1. **stdin `rate_limits`** — Claude Code (v2.1+) sends `rate_limits` directly in the session JSON for Pro/Max subscribers. When present, cship uses this data immediately with zero latency and no credential setup required.
 2. **OAuth API fetch** — Falls back to fetching from `https://api.anthropic.com/api/oauth/usage` using your OAuth token (stored in the OS credential store). Results are cached for the configured TTL (default 60s).
 
-**Token:** `$cship.usage_limits`
+**Tokens:**
+
+| Token | Renders |
+|-------|---------|
+| `$cship.usage_limits` | Combined: 5h + 7d + per-model (when present) + extra usage (when enabled) |
+| `$cship.usage_limits.per_model` | Only the per-model 7-day breakdown (opus/sonnet/cowork/oauth) |
+| `$cship.usage_limits.opus` | 7-day Opus utilization only |
+| `$cship.usage_limits.sonnet` | 7-day Sonnet utilization only |
+| `$cship.usage_limits.cowork` | 7-day Cowork utilization only |
+| `$cship.usage_limits.oauth_apps` | 7-day OAuth-apps utilization only |
+| `$cship.usage_limits.extra_usage` | Extra-credits display (only when the account has extra usage enabled) |
+
+The sub-tokens let you place sections independently in your `lines` layout — e.g., keep the 5h/7d pair on one row and push per-model onto a second row.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `disabled` | `bool` | `false` | Hide this module |
 | `style` | `string` | — | Base ANSI style |
-| `format` | `string` | — | Format string |
-| `five_hour_format` | `string` | `"5h: {pct}% resets in {reset}"` | Format for the 5h window. Placeholders: `{pct}` (% used), `{remaining}` (% left), `{reset}` (time to reset) |
-| `seven_day_format` | `string` | `"7d: {pct}% resets in {reset}"` | Format for the 7d window. Same placeholders as above |
-| `separator` | `string` | `" \| "` | String placed between 5h and 7d sections |
+| `format` | `string` | — | Reserved; use the per-section formats below |
+| `five_hour_format` | `string` | `"5h: {pct}% resets in {reset}"` | Format for the 5h window |
+| `seven_day_format` | `string` | `"7d: {pct}% resets in {reset}"` | Format for the 7d window |
+| `opus_format` | `string` | `"opus {pct}%"` | Format for the 7-day Opus section |
+| `sonnet_format` | `string` | `"sonnet {pct}%"` | Format for the 7-day Sonnet section |
+| `cowork_format` | `string` | `"cowork {pct}%"` | Format for the 7-day Cowork section |
+| `oauth_apps_format` | `string` | `"oauth {pct}%"` | Format for the 7-day OAuth-apps section |
+| `extra_usage_format` | `string` | `"{active} extra: {pct}% (${used}/${limit})"` | Format for the extra-usage section |
+| `separator` | `string` | `" \| "` | String placed between sections |
 | `warn_threshold` | `float` | — | % at which style switches to `warn_style` |
 | `warn_style` | `string` | `"yellow"` | Style at warn level |
 | `critical_threshold` | `float` | — | % at which style switches to `critical_style` |
 | `critical_style` | `string` | `"bold red"` | Style at critical level |
 | `ttl` | `integer` | `60` | Cache refresh interval in seconds. Increase to reduce API pressure when running multiple concurrent sessions. |
 
-**Prerequisites:** If Claude Code sends `rate_limits` in its session JSON (v2.1+, Pro/Max plans), no setup is needed. Otherwise, on Linux/WSL2 install `libsecret-tools` and store your OAuth token with `secret-tool`. See [FAQ](/faq#usage-limits-linux) for setup instructions.
+**Placeholders** (available in all `*_format` strings):
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `{pct}` | Percentage used as integer (e.g. `23`) |
+| `{remaining}` | Percentage remaining as integer (e.g. `77`) |
+| `{reset}` | Time-until-reset string (e.g. `4h12m`) |
+| `{pace}` | Signed headroom vs linear consumption — `+20%` (under pace), `-15%` (over pace), or `?` when unknown |
+
+**Additional placeholders in `extra_usage_format`:**
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `{used}` | Extra credits consumed, in dollars (e.g. `12.34`) |
+| `{limit}` | Monthly extra-credit limit, in dollars (e.g. `50`) |
+| `{active}` | `⚡` when 5h or 7d utilization is at 100% (actively consuming extra credits), `💤` otherwise |
+
+**Prerequisites:** If Claude Code sends `rate_limits` in its session JSON (v2.1+, Pro/Max plans), no setup is needed for the 5h/7d totals. Per-model breakdowns and extra-usage data always come from the OAuth API — on Linux/WSL2 install `libsecret-tools` and store your OAuth token with `secret-tool`. See [FAQ](/faq#usage-limits-linux) for setup instructions.
 
 ```toml
 [cship.usage_limits]
 ttl                = 300       # 5 minutes; increase if you run many concurrent sessions
-five_hour_format   = "5h({remaining}% left)"
-seven_day_format   = "7d({remaining}% left)"
-separator          = " "
+five_hour_format   = "5h {pct}% ({pace}, {reset})"
+seven_day_format   = "7d {pct}% ({pace}, {reset})"
+opus_format        = "opus {pct}%"
+sonnet_format      = "sonnet {pct}%"
+extra_usage_format = "{active} extra {pct}% (${used}/${limit})"
+separator          = " | "
 warn_threshold     = 70.0
 warn_style         = "bold yellow"
 critical_threshold = 90.0
 critical_style     = "bold red"
 ```
 
+### Composing with sub-tokens
+
+Place per-model and extra usage on a separate line from the 5h/7d summary:
+
+```toml
+[cship]
+lines = [
+  "$cship.model $cship.cost",
+  "$cship.usage_limits",
+  "$cship.usage_limits.per_model $cship.usage_limits.extra_usage",
+]
+```
+
+Each sub-token returns nothing when its data is absent, so the row collapses cleanly on accounts without a given breakdown.
+
 ### Hiding a usage period
 
-To hide one of the two usage periods, set its format **and** the separator to empty strings. For example, to show only the 5-hour window:
+To hide one of the two main windows, set its format **and** the separator to empty strings. For example, to show only the 5-hour window:
 
 ```toml
 [cship.usage_limits]
@@ -352,7 +404,7 @@ five_hour_format = ""
 separator        = ""
 ```
 
-Setting both formats to `""` effectively hides the entire module.
+Setting both formats to `""` effectively hides the combined token. Per-model sections render only when the API returns data for that model, so they disappear automatically on accounts that don't expose a given breakdown.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,6 +64,23 @@ The CShip `usage_limits` module fetches data from the Anthropic API using your C
 
 ---
 
+## What do `{pace}` and `{active}` mean in the usage_limits format strings?
+
+**`{pace}`** is the signed headroom versus linear consumption of the current window. If you were perfectly on pace to land at 100% exactly when the window resets, `{pace}` would be `0%`. A positive value (e.g. `+20%`) means you have 20 percentage points of headroom over the linear pace — you can comfortably keep going. A negative value (e.g. `-15%`) means you're 15 points ahead of pace and will hit the limit before reset unless you slow down. It renders as `?` when the reset time is unknown.
+
+`{pace}` is available in `five_hour_format`, `seven_day_format`, and each per-model format (`opus_format`, `sonnet_format`, `cowork_format`, `oauth_apps_format`).
+
+**`{active}`** is only available in `extra_usage_format`. It renders `⚡` when either the 5h or 7d window is at 100% — meaning fresh requests are now drawing down extra credits rather than plan credits — and `💤` otherwise. Pair it with `{used}` / `{limit}` (dollars) and `{pct}` (utilization of the monthly extra-credit cap) for a one-glance view of supplemental spend.
+
+```toml
+[cship.usage_limits]
+five_hour_format   = "5h {pct}% ({pace})"
+seven_day_format   = "7d {pct}% ({pace})"
+extra_usage_format = "{active} ${used}/${limit}"
+```
+
+---
+
 ## How does the peak-time indicator handle time zones and DST?
 
 The `peak_usage` module checks whether the current time falls within the configured peak window in **US Pacific time**. It computes the UTC→Pacific offset internally — PDT (UTC−7) from the second Sunday of March through the first Sunday of November, PST (UTC−8) the rest of the year.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -287,20 +287,7 @@ mod tests {
             seven_day_pct: 45.1,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         }
     }
 
@@ -378,20 +365,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2000-01-01T00:00:00Z".into(), // past
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(), // future
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -430,20 +404,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(), // future
             seven_day_resets_at: "2000-01-01T00:00:00Z".into(), // past
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -462,22 +423,7 @@ mod tests {
         let data = UsageLimitsData {
             five_hour_pct: 50.0,
             seven_day_pct: 10.0,
-            five_hour_resets_at: String::new(),
-            seven_day_resets_at: String::new(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -587,17 +533,11 @@ mod tests {
         assert!((data.five_hour_pct - 42.0).abs() < f64::EPSILON);
         assert!((data.seven_day_pct - 18.0).abs() < f64::EPSILON);
         // All new fields should be None (backwards-compatible defaults)
-        assert!(
-            data.extra_usage_enabled.is_none(),
-            "extra_usage_enabled should default to None"
-        );
+        assert!(data.extra_usage_enabled.is_none());
         assert!(data.extra_usage_monthly_limit.is_none());
         assert!(data.extra_usage_used_credits.is_none());
         assert!(data.extra_usage_utilization.is_none());
-        assert!(
-            data.seven_day_opus_pct.is_none(),
-            "seven_day_opus_pct should default to None"
-        );
+        assert!(data.seven_day_opus_pct.is_none());
         assert!(data.seven_day_opus_resets_at.is_none());
         assert!(data.seven_day_sonnet_pct.is_none());
         assert!(data.seven_day_sonnet_resets_at.is_none());
@@ -619,20 +559,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2000-01-01T00:00:00+00:00".into(), // past, +00:00 format
             seven_day_resets_at: "2099-01-01T00:00:00+00:00".into(), // future
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -289,6 +289,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         }
     }
 
@@ -368,6 +380,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(), // future
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -408,6 +432,18 @@ mod tests {
             seven_day_resets_at: "2000-01-01T00:00:00Z".into(), // past
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -430,6 +466,18 @@ mod tests {
             seven_day_resets_at: String::new(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);
@@ -517,6 +565,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00+00:00".into(), // future
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         write_usage_limits(&transcript, &data, 60);
         let result = read_usage_limits(&transcript, false);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -553,6 +553,62 @@ mod tests {
     }
 
     #[test]
+    fn test_usage_limits_cache_backwards_compat_old_format() {
+        // Old cache JSON (pre-extra-usage/per-model) must still deserialize.
+        // The old format lacks extra_usage_*, seven_day_opus_*, etc. fields —
+        // #[serde(default)] on UsageLimitsData ensures they deserialize as None.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript = dir.path().join("transcript.jsonl");
+        // Write a cache file mimicking the old format (only original fields)
+        let path = dir.path().join("cship").join("transcript-usage-limits");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let old_cache = serde_json::json!({
+            "data": {
+                "five_hour_pct": 42.0,
+                "seven_day_pct": 18.0,
+                "five_hour_resets_at": "2099-01-01T00:00:00Z",
+                "seven_day_resets_at": "2099-01-01T00:00:00Z"
+            },
+            "expires_at": now + 300,
+            "five_hour_resets_at": 9_999_999_999_u64,
+            "seven_day_resets_at": 9_999_999_999_u64
+        });
+        std::fs::write(&path, serde_json::to_string(&old_cache).unwrap()).unwrap();
+        let result = read_usage_limits(&transcript, false);
+        assert!(
+            result.is_some(),
+            "old-format cache should still deserialize"
+        );
+        let data = result.unwrap();
+        assert!((data.five_hour_pct - 42.0).abs() < f64::EPSILON);
+        assert!((data.seven_day_pct - 18.0).abs() < f64::EPSILON);
+        // All new fields should be None (backwards-compatible defaults)
+        assert!(
+            data.extra_usage_enabled.is_none(),
+            "extra_usage_enabled should default to None"
+        );
+        assert!(data.extra_usage_monthly_limit.is_none());
+        assert!(data.extra_usage_used_credits.is_none());
+        assert!(data.extra_usage_utilization.is_none());
+        assert!(
+            data.seven_day_opus_pct.is_none(),
+            "seven_day_opus_pct should default to None"
+        );
+        assert!(data.seven_day_opus_resets_at.is_none());
+        assert!(data.seven_day_sonnet_pct.is_none());
+        assert!(data.seven_day_sonnet_resets_at.is_none());
+        assert!(data.seven_day_cowork_pct.is_none());
+        assert!(data.seven_day_cowork_resets_at.is_none());
+        assert!(data.seven_day_oauth_apps_pct.is_none());
+        assert!(data.seven_day_oauth_apps_resets_at.is_none());
+        drop(dir);
+    }
+
+    #[test]
     fn test_usage_limits_early_invalidation_with_plus_offset_resets_at() {
         // Real API returns "+00:00" format — early invalidation must fire correctly
         let dir = tempfile::tempdir().expect("tempdir");

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -170,6 +170,40 @@ pub fn write_usage_limits(transcript_path: &Path, data: &UsageLimitsData, ttl_se
     }
 }
 
+// ── Negative cache marker ────────────────────────────────────────────────────
+
+/// Path for the negative cache marker (same directory as usage-limits cache).
+fn negative_marker_path(transcript_path: &Path) -> Option<std::path::PathBuf> {
+    let dir = transcript_path.parent()?;
+    let stem = transcript_path.file_stem()?.to_str()?;
+    Some(dir.join("cship").join(format!("{stem}-usage-limits-fail")))
+}
+
+/// Returns `true` if a recent failure marker exists and hasn't expired.
+pub fn read_negative_marker(transcript_path: &Path) -> bool {
+    let Some(path) = negative_marker_path(transcript_path) else {
+        return false;
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let Ok(expires_at) = raw.trim().parse::<u64>() else {
+        return false;
+    };
+    now_epoch() < expires_at
+}
+
+/// Write a failure marker that expires in `cooldown_secs`.
+pub fn write_negative_marker(transcript_path: &Path, cooldown_secs: u64) {
+    let Some(path) = negative_marker_path(transcript_path) else {
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(path, (now_epoch() + cooldown_secs).to_string());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,10 +274,16 @@ pub struct UsageLimitsConfig {
     /// Default: "opus {pct}%"
     pub opus_format: Option<String>,
     /// Format string for 7-day Sonnet breakdown.
+    /// Placeholders: {pct}, {reset}, {remaining}
+    /// Default: "sonnet {pct}%"
     pub sonnet_format: Option<String>,
     /// Format string for 7-day Cowork breakdown.
+    /// Placeholders: {pct}, {reset}, {remaining}
+    /// Default: "cowork {pct}%"
     pub cowork_format: Option<String>,
     /// Format string for 7-day OAuth apps breakdown.
+    /// Placeholders: {pct}, {reset}, {remaining}
+    /// Default: "oauth {pct}%"
     pub oauth_apps_format: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,20 @@ pub struct UsageLimitsConfig {
     pub five_hour_format: Option<String>,
     pub seven_day_format: Option<String>,
     pub separator: Option<String>,
+    /// Format string for extra usage display. Shown when extra_usage.is_enabled is true.
+    /// Placeholders: {pct}, {used}, {limit}, {remaining}
+    /// Default: "extra: {pct}% (${used}/${limit})"
+    pub extra_usage_format: Option<String>,
+    /// Format string for 7-day Opus breakdown. Shown when API returns non-null data.
+    /// Placeholders: {pct}, {reset}, {remaining}
+    /// Default: "opus {pct}%"
+    pub opus_format: Option<String>,
+    /// Format string for 7-day Sonnet breakdown.
+    pub sonnet_format: Option<String>,
+    /// Format string for 7-day Cowork breakdown.
+    pub cowork_format: Option<String>,
+    /// Format string for 7-day OAuth apps breakdown.
+    pub oauth_apps_format: Option<String>,
 }
 
 /// Configuration for `[cship.peak_usage]` — peak-time indicator.

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -45,6 +45,12 @@ pub const ALL_NATIVE_MODULES: &[&str] = &[
     "cship.workspace.current_dir",
     "cship.workspace.project_dir",
     "cship.usage_limits",
+    "cship.usage_limits.per_model",
+    "cship.usage_limits.opus",
+    "cship.usage_limits.sonnet",
+    "cship.usage_limits.cowork",
+    "cship.usage_limits.oauth_apps",
+    "cship.usage_limits.extra_usage",
     "cship.peak_usage",
 ];
 
@@ -111,6 +117,12 @@ pub fn render_module(
         "cship.workspace.project_dir" => workspace::render_project_dir(ctx, cfg),
         // Usage limits module — non-blocking thread dispatch for live API data
         "cship.usage_limits" => usage_limits::render(ctx, cfg),
+        "cship.usage_limits.per_model" => usage_limits::render_per_model(ctx, cfg),
+        "cship.usage_limits.opus" => usage_limits::render_opus(ctx, cfg),
+        "cship.usage_limits.sonnet" => usage_limits::render_sonnet(ctx, cfg),
+        "cship.usage_limits.cowork" => usage_limits::render_cowork(ctx, cfg),
+        "cship.usage_limits.oauth_apps" => usage_limits::render_oauth_apps(ctx, cfg),
+        "cship.usage_limits.extra_usage" => usage_limits::render_extra_usage(ctx, cfg),
         // Peak usage indicator — time-based peak-hour check
         "cship.peak_usage" => peak_usage::render(ctx, cfg),
         other => {

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -200,14 +200,22 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     const FIVE_HOUR_SECS: u64 = 18_000;
     const SEVEN_DAY_SECS: u64 = 604_800;
 
-    let five_h_resets_epoch = data.five_hour_resets_at_epoch.or_else(|| {
-        crate::cache::iso8601_to_epoch(&data.five_hour_resets_at)
-    });
-    let seven_d_resets_epoch = data.seven_day_resets_at_epoch.or_else(|| {
-        crate::cache::iso8601_to_epoch(&data.seven_day_resets_at)
-    });
-    let five_h_pace = format_pace(calculate_pace(data.five_hour_pct, five_h_resets_epoch, FIVE_HOUR_SECS));
-    let seven_d_pace = format_pace(calculate_pace(data.seven_day_pct, seven_d_resets_epoch, SEVEN_DAY_SECS));
+    let five_h_resets_epoch = data
+        .five_hour_resets_at_epoch
+        .or_else(|| crate::cache::iso8601_to_epoch(&data.five_hour_resets_at));
+    let seven_d_resets_epoch = data
+        .seven_day_resets_at_epoch
+        .or_else(|| crate::cache::iso8601_to_epoch(&data.seven_day_resets_at));
+    let five_h_pace = format_pace(calculate_pace(
+        data.five_hour_pct,
+        five_h_resets_epoch,
+        FIVE_HOUR_SECS,
+    ));
+    let seven_d_pace = format_pace(calculate_pace(
+        data.seven_day_pct,
+        seven_d_resets_epoch,
+        SEVEN_DAY_SECS,
+    ));
 
     let five_h_fmt = cfg
         .five_hour_format
@@ -234,10 +242,30 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     // --- Per-model 7-day breakdowns ---
     #[allow(clippy::type_complexity)]
     let model_entries: &[(&str, Option<f64>, &Option<String>, Option<&str>)] = &[
-        ("opus", data.seven_day_opus_pct, &data.seven_day_opus_resets_at, cfg.opus_format.as_deref()),
-        ("sonnet", data.seven_day_sonnet_pct, &data.seven_day_sonnet_resets_at, cfg.sonnet_format.as_deref()),
-        ("cowork", data.seven_day_cowork_pct, &data.seven_day_cowork_resets_at, cfg.cowork_format.as_deref()),
-        ("oauth", data.seven_day_oauth_apps_pct, &data.seven_day_oauth_apps_resets_at, cfg.oauth_apps_format.as_deref()),
+        (
+            "opus",
+            data.seven_day_opus_pct,
+            &data.seven_day_opus_resets_at,
+            cfg.opus_format.as_deref(),
+        ),
+        (
+            "sonnet",
+            data.seven_day_sonnet_pct,
+            &data.seven_day_sonnet_resets_at,
+            cfg.sonnet_format.as_deref(),
+        ),
+        (
+            "cowork",
+            data.seven_day_cowork_pct,
+            &data.seven_day_cowork_resets_at,
+            cfg.cowork_format.as_deref(),
+        ),
+        (
+            "oauth",
+            data.seven_day_oauth_apps_pct,
+            &data.seven_day_oauth_apps_resets_at,
+            cfg.oauth_apps_format.as_deref(),
+        ),
     ];
 
     for (name, pct_opt, resets_at_opt, fmt_opt) in model_entries {
@@ -260,10 +288,22 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
 
     // --- Extra usage ---
     if data.extra_usage_enabled == Some(true) {
-        let eu_pct = data.extra_usage_utilization.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
-        let eu_used = data.extra_usage_used_credits.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
-        let eu_limit = data.extra_usage_monthly_limit.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
-        let eu_remaining = match (data.extra_usage_monthly_limit, data.extra_usage_used_credits) {
+        let eu_pct = data
+            .extra_usage_utilization
+            .map(|v| format!("{:.0}", v))
+            .unwrap_or_else(|| "?".into());
+        let eu_used = data
+            .extra_usage_used_credits
+            .map(|v| format!("{:.0}", v))
+            .unwrap_or_else(|| "?".into());
+        let eu_limit = data
+            .extra_usage_monthly_limit
+            .map(|v| format!("{:.0}", v))
+            .unwrap_or_else(|| "?".into());
+        let eu_remaining = match (
+            data.extra_usage_monthly_limit,
+            data.extra_usage_used_credits,
+        ) {
             (Some(limit), Some(used)) => format!("{:.0}", (limit - used).max(0.0)),
             _ => "?".into(),
         };
@@ -1447,6 +1487,24 @@ mod tests {
     }
 
     #[test]
+    fn test_calculate_pace_zero_elapsed() {
+        // Window just started — resets_at is exactly window_secs in the future.
+        // expected_pct ≈ 0%, so pace ≈ -used_pct.
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let resets_at_epoch = now_epoch + 18000; // full 5h remaining
+        let pace = calculate_pace(10.0, Some(resets_at_epoch), 18000);
+        let p = pace.unwrap();
+        // elapsed ≈ 0, expected_pct ≈ 0, pace ≈ 0 - 10 = -10
+        assert!(
+            p > -15.0 && p < -5.0,
+            "expected ~-10 over-pace at zero elapsed, got {p}"
+        );
+    }
+
+    #[test]
     fn test_calculate_pace_reset_in_past() {
         let now_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1513,7 +1571,10 @@ mod tests {
             ..Default::default()
         };
         let result = format_output(&data, &cfg);
-        assert!(result.contains("pace:+"), "expected positive pace in: {result:?}");
+        assert!(
+            result.contains("pace:+"),
+            "expected positive pace in: {result:?}"
+        );
         assert!(result.contains("5h 30%"), "expected 5h 30% in: {result:?}");
     }
 
@@ -1545,7 +1606,10 @@ mod tests {
             ..Default::default()
         };
         let result = format_output(&data, &cfg);
-        assert!(result.contains("pace:?"), "expected ? for unknown pace in: {result:?}");
+        assert!(
+            result.contains("pace:?"),
+            "expected ? for unknown pace in: {result:?}"
+        );
     }
 
     // ── extra usage in format_output() tests ─────────────────────────────────
@@ -1580,7 +1644,10 @@ mod tests {
         let result = format_output(&data, &cfg);
         assert!(result.contains("100%"), "five_hour in: {result:?}");
         assert!(result.contains("50%"), "seven_day in: {result:?}");
-        assert!(result.contains("extra:"), "extra usage default format in: {result:?}");
+        assert!(
+            result.contains("extra:"),
+            "extra usage default format in: {result:?}"
+        );
         assert!(result.contains("31%"), "extra pct in: {result:?}");
         assert!(result.contains("6195"), "used credits in: {result:?}");
         assert!(result.contains("20000"), "monthly limit in: {result:?}");
@@ -1610,7 +1677,10 @@ mod tests {
         };
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
-        assert!(!result.contains("extra"), "extra usage should be hidden when disabled: {result:?}");
+        assert!(
+            !result.contains("extra"),
+            "extra usage should be hidden when disabled: {result:?}"
+        );
     }
 
     #[test]
@@ -1637,7 +1707,10 @@ mod tests {
         };
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
-        assert!(!result.contains("extra"), "extra usage should be absent: {result:?}");
+        assert!(
+            !result.contains("extra"),
+            "extra usage should be absent: {result:?}"
+        );
     }
 
     #[test]
@@ -1670,7 +1743,10 @@ mod tests {
         };
         let result = format_output(&data, &cfg);
         assert!(result.contains("EXTRA 31%"), "custom format: {result:?}");
-        assert!(result.contains("rem:13805"), "remaining credits: {result:?}");
+        assert!(
+            result.contains("rem:13805"),
+            "remaining credits: {result:?}"
+        );
     }
 
     // ── per-model in format_output() tests ───────────────────────────────────
@@ -1704,9 +1780,18 @@ mod tests {
         };
         let result = format_output(&data, &cfg);
         assert!(result.contains("opus 12%"), "opus breakdown in: {result:?}");
-        assert!(result.contains("sonnet 3%"), "sonnet breakdown in: {result:?}");
-        assert!(!result.contains("cowork"), "null cowork should be omitted: {result:?}");
-        assert!(!result.contains("oauth"), "null oauth_apps should be omitted: {result:?}");
+        assert!(
+            result.contains("sonnet 3%"),
+            "sonnet breakdown in: {result:?}"
+        );
+        assert!(
+            !result.contains("cowork"),
+            "null cowork should be omitted: {result:?}"
+        );
+        assert!(
+            !result.contains("oauth"),
+            "null oauth_apps should be omitted: {result:?}"
+        );
     }
 
     #[test]
@@ -1738,7 +1823,10 @@ mod tests {
             ..Default::default()
         };
         let result = format_output(&data, &cfg);
-        assert!(result.contains("OP:12%/88%"), "custom opus format: {result:?}");
+        assert!(
+            result.contains("OP:12%/88%"),
+            "custom opus format: {result:?}"
+        );
     }
 
     #[test]

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -141,24 +141,9 @@ fn data_from_stdin_rate_limits(ctx: &Context) -> Option<UsageLimitsData> {
     Some(UsageLimitsData {
         five_hour_pct: five_pct,
         seven_day_pct: seven_pct,
-        // ISO string fields unused on the stdin path — epoch fields carry the reset time.
-        five_hour_resets_at: String::new(),
-        seven_day_resets_at: String::new(),
         five_hour_resets_at_epoch: five_epoch,
         seven_day_resets_at_epoch: seven_epoch,
-        // Extra usage and per-model fields are only populated on the OAuth path.
-        extra_usage_enabled: None,
-        extra_usage_monthly_limit: None,
-        extra_usage_used_credits: None,
-        extra_usage_utilization: None,
-        seven_day_opus_pct: None,
-        seven_day_opus_resets_at: None,
-        seven_day_sonnet_pct: None,
-        seven_day_sonnet_resets_at: None,
-        seven_day_cowork_pct: None,
-        seven_day_cowork_resets_at: None,
-        seven_day_oauth_apps_pct: None,
-        seven_day_oauth_apps_resets_at: None,
+        ..Default::default()
     })
 }
 
@@ -179,42 +164,32 @@ fn data_from_stdin_rate_limits(ctx: &Context) -> Option<UsageLimitsData> {
 /// - `separator`: `" | "`
 fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     let sep = cfg.separator.as_deref().unwrap_or(" | ");
+    let now = now_epoch();
 
-    // --- Five-hour part ---
-    let five_h_pct = format!("{:.0}", data.five_hour_pct);
-    let five_h_remaining = format!("{:.0}", (100.0 - data.five_hour_pct).max(0.0));
-    let five_h_reset = match data.five_hour_resets_at_epoch {
-        Some(epoch) => format_time_until_epoch(epoch),
-        None => format_time_until(&data.five_hour_resets_at),
-    };
-
-    // --- Seven-day part ---
-    let seven_d_pct = format!("{:.0}", data.seven_day_pct);
-    let seven_d_remaining = format!("{:.0}", (100.0 - data.seven_day_pct).max(0.0));
-    let seven_d_reset = match data.seven_day_resets_at_epoch {
-        Some(epoch) => format_time_until_epoch(epoch),
-        None => format_time_until(&data.seven_day_resets_at),
-    };
-
-    // --- Pace calculation ---
     const FIVE_HOUR_SECS: u64 = 18_000;
     const SEVEN_DAY_SECS: u64 = 604_800;
 
-    let five_h_resets_epoch = data
-        .five_hour_resets_at_epoch
-        .or_else(|| crate::cache::iso8601_to_epoch(&data.five_hour_resets_at));
-    let seven_d_resets_epoch = data
-        .seven_day_resets_at_epoch
-        .or_else(|| crate::cache::iso8601_to_epoch(&data.seven_day_resets_at));
+    let five_h_epoch = resolve_epoch(data.five_hour_resets_at_epoch, &data.five_hour_resets_at);
+    let seven_d_epoch = resolve_epoch(data.seven_day_resets_at_epoch, &data.seven_day_resets_at);
+
+    let five_h_pct = format!("{:.0}", data.five_hour_pct);
+    let five_h_remaining = format!("{:.0}", (100.0 - data.five_hour_pct).max(0.0));
+    let five_h_reset = format_reset(five_h_epoch, now);
     let five_h_pace = format_pace(calculate_pace(
         data.five_hour_pct,
-        five_h_resets_epoch,
+        five_h_epoch,
         FIVE_HOUR_SECS,
+        now,
     ));
+
+    let seven_d_pct = format!("{:.0}", data.seven_day_pct);
+    let seven_d_remaining = format!("{:.0}", (100.0 - data.seven_day_pct).max(0.0));
+    let seven_d_reset = format_reset(seven_d_epoch, now);
     let seven_d_pace = format_pace(calculate_pace(
         data.seven_day_pct,
-        seven_d_resets_epoch,
+        seven_d_epoch,
         SEVEN_DAY_SECS,
+        now,
     ));
 
     let five_h_fmt = cfg
@@ -239,7 +214,6 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
 
     let mut parts: Vec<String> = vec![five_h_part, seven_d_part];
 
-    // --- Per-model 7-day breakdowns ---
     #[allow(clippy::type_complexity)]
     let model_entries: &[(&str, Option<f64>, &Option<String>, Option<&str>)] = &[
         (
@@ -273,11 +247,17 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
             let pct_str = format!("{:.0}", pct);
             let remaining_str = format!("{:.0}", (100.0 - pct).max(0.0));
             let reset_str = match resets_at_opt {
-                Some(s) => format_time_until(s),
+                Some(s) => format_reset(crate::cache::iso8601_to_epoch(s), now),
                 None => "?".to_string(),
             };
-            let default_fmt = format!("{name} {{pct}}%");
-            let fmt = fmt_opt.unwrap_or(&default_fmt);
+            let default_fmt;
+            let fmt: &str = match fmt_opt {
+                Some(f) => f,
+                None => {
+                    default_fmt = format!("{name} {{pct}}%");
+                    &default_fmt
+                }
+            };
             let rendered = fmt
                 .replace("{pct}", &pct_str)
                 .replace("{remaining}", &remaining_str)
@@ -286,7 +266,6 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
         }
     }
 
-    // --- Extra usage ---
     if data.extra_usage_enabled == Some(true) {
         let eu_pct = data
             .extra_usage_utilization
@@ -322,55 +301,31 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     parts.join(sep)
 }
 
-/// Convert a Unix epoch reset timestamp to a human-readable time-until string.
-///
-/// This is the epoch-native equivalent of `format_time_until`, used on the stdin path
-/// to avoid a round-trip through ISO 8601 formatting and re-parsing.
-///
-/// - Past timestamp → `"now"`
-/// - < 1 hour → `"45m"`
-/// - < 1 day → `"4h12m"`
-/// - >= 1 day → `"3d2h"`
-fn format_time_until_epoch(reset_epoch: u64) -> String {
-    let now = std::time::SystemTime::now()
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0);
-    if now >= reset_epoch {
-        return "now".to_string();
-    }
-    format_remaining_secs(reset_epoch - now)
+        .unwrap_or(0)
 }
 
-/// Convert an ISO 8601 reset timestamp to a human-readable time-until string.
-///
-/// - Empty string → `"?"`
-/// - Unparseable → `"?"`
-/// - Past timestamp → `"now"`
-/// - < 1 hour → `"45m"`
-/// - < 1 day → `"4h12m"`
-/// - >= 1 day → `"3d2h"`
-fn format_time_until(resets_at: &str) -> String {
-    if resets_at.is_empty() {
-        return "?".to_string();
+/// Resolve a reset epoch: prefer a pre-computed epoch, fall back to parsing an ISO 8601 string.
+fn resolve_epoch(epoch: Option<u64>, iso: &str) -> Option<u64> {
+    epoch.or_else(|| crate::cache::iso8601_to_epoch(iso))
+}
+
+/// Format a resolved epoch as a human-readable time-until string.
+/// `None` → `"?"`, past → `"now"`, otherwise `"4h12m"` / `"3d2h"` / `"45m"`.
+fn format_reset(epoch: Option<u64>, now: u64) -> String {
+    match epoch {
+        None => "?".to_string(),
+        Some(e) if now >= e => "now".to_string(),
+        Some(e) => format_remaining_secs(e - now),
     }
-    let reset_epoch = match crate::cache::iso8601_to_epoch(resets_at) {
-        Some(e) => e,
-        None => return "?".to_string(),
-    };
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    if now >= reset_epoch {
-        return "now".to_string();
-    }
-    format_remaining_secs(reset_epoch - now)
 }
 
 /// Format a number of remaining seconds as a compact human-readable string.
 ///
-/// Shared arithmetic used by both `format_time_until_epoch` and `format_time_until`.
+/// Shared arithmetic used by `format_reset`.
 ///
 /// - < 1 hour → `"45m"`
 /// - < 1 day → `"4h12m"`
@@ -392,16 +347,13 @@ fn format_remaining_secs(secs: u64) -> String {
 ///
 /// Returns `Some(pace)` where positive = headroom, negative = over-pace.
 /// Returns `None` when `resets_at_epoch` is unavailable.
-///
-/// - `used_pct`: current utilization percentage (0-100+)
-/// - `resets_at_epoch`: Unix epoch when the window resets; `None` = unknown
-/// - `window_secs`: total window duration in seconds (18000 for 5h, 604800 for 7d)
-fn calculate_pace(used_pct: f64, resets_at_epoch: Option<u64>, window_secs: u64) -> Option<f64> {
+fn calculate_pace(
+    used_pct: f64,
+    resets_at_epoch: Option<u64>,
+    window_secs: u64,
+    now: u64,
+) -> Option<f64> {
     let reset = resets_at_epoch?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
     let remaining = reset.saturating_sub(now);
     let elapsed = window_secs.saturating_sub(remaining);
     let elapsed_fraction = elapsed as f64 / window_secs as f64;
@@ -461,6 +413,16 @@ mod tests {
         }
     }
 
+    fn sample_data() -> UsageLimitsData {
+        UsageLimitsData {
+            five_hour_pct: 23.4,
+            seven_day_pct: 45.1,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            ..Default::default()
+        }
+    }
+
     // ── render() tests ────────────────────────────────────────────────────────
 
     #[test]
@@ -490,26 +452,7 @@ mod tests {
     fn test_render_cache_hit_returns_formatted_output() {
         let dir = tempfile::tempdir().unwrap();
         let transcript = dir.path().join("test.jsonl");
-        let data = UsageLimitsData {
-            five_hour_pct: 23.4,
-            seven_day_pct: 45.1,
-            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
-            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
-        };
+        let data = sample_data();
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
         let ctx = Context {
@@ -532,20 +475,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -577,20 +507,7 @@ mod tests {
             seven_day_pct: 20.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -627,20 +544,7 @@ mod tests {
             seven_day_pct: 85.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -677,20 +581,7 @@ mod tests {
             seven_day_pct: 30.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
         // Verify read_usage_limits(allow_stale=true) works even after TTL would normally expire
@@ -709,20 +600,7 @@ mod tests {
             seven_day_pct: 30.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cloned = expected.clone();
         let result = fetch_with_timeout(move || Ok(cloned));
@@ -741,26 +619,7 @@ mod tests {
     fn test_fetch_with_timeout_timeout_returns_none() {
         let result = fetch_with_timeout(|| {
             std::thread::sleep(std::time::Duration::from_secs(5));
-            Ok(UsageLimitsData {
-                five_hour_pct: 0.0,
-                seven_day_pct: 0.0,
-                five_hour_resets_at: String::new(),
-                seven_day_resets_at: String::new(),
-                five_hour_resets_at_epoch: None,
-                seven_day_resets_at_epoch: None,
-                extra_usage_enabled: None,
-                extra_usage_monthly_limit: None,
-                extra_usage_used_credits: None,
-                extra_usage_utilization: None,
-                seven_day_opus_pct: None,
-                seven_day_opus_resets_at: None,
-                seven_day_sonnet_pct: None,
-                seven_day_sonnet_resets_at: None,
-                seven_day_cowork_pct: None,
-                seven_day_cowork_resets_at: None,
-                seven_day_oauth_apps_pct: None,
-                seven_day_oauth_apps_resets_at: None,
-            })
+            Ok(UsageLimitsData::default())
         });
         assert!(result.is_none());
     }
@@ -789,27 +648,31 @@ mod tests {
         assert_eq!(epoch_to_iso(Some(4_102_358_400)), "2099-12-31T00:00:00Z");
     }
 
-    // ── format_time_until() tests ─────────────────────────────────────────────
-
-    #[test]
-    fn test_format_time_until_empty_string_returns_question_mark() {
-        assert_eq!(format_time_until(""), "?");
-    }
-
-    #[test]
-    fn test_format_time_until_past_timestamp_returns_now() {
-        assert_eq!(format_time_until("2000-01-01T00:00:00Z"), "now");
-    }
-
-    #[test]
-    fn test_format_time_until_hours_minutes() {
-        let now = std::time::SystemTime::now()
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_secs();
-        let future_epoch = now + 4 * 3600 + 12 * 60 + 30; // ~4h12m from now
-        let future_str = epoch_to_iso(Some(future_epoch));
-        let result = format_time_until(&future_str);
+            .as_secs()
+    }
+
+    // ── format_reset() tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_reset_none_returns_question_mark() {
+        assert_eq!(format_reset(None, now_secs()), "?");
+    }
+
+    #[test]
+    fn test_format_reset_past_returns_now() {
+        let now = now_secs();
+        assert_eq!(format_reset(Some(0), now), "now");
+        assert_eq!(format_reset(Some(now.saturating_sub(1)), now), "now");
+    }
+
+    #[test]
+    fn test_format_reset_hours_minutes() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 4 * 3600 + 12 * 60 + 30), now);
         assert!(
             result.contains('h') && result.contains('m'),
             "expected Xh Ym format: {result}"
@@ -817,14 +680,9 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_days_hours() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let future_epoch = now + 3 * 86400 + 2 * 3600 + 30; // ~3d2h from now
-        let future_str = epoch_to_iso(Some(future_epoch));
-        let result = format_time_until(&future_str);
+    fn test_format_reset_days_hours() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 3 * 86400 + 2 * 3600 + 30), now);
         assert!(
             result.contains('d') && result.contains('h'),
             "expected Xd Yh format: {result}"
@@ -832,14 +690,9 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_minutes_only() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let future_epoch = now + 45 * 60 + 30; // ~45m from now
-        let future_str = epoch_to_iso(Some(future_epoch));
-        let result = format_time_until(&future_str);
+    fn test_format_reset_minutes_only() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 45 * 60 + 30), now);
         assert!(
             result.ends_with('m') && !result.contains('h'),
             "expected Xm format: {result}"
@@ -847,15 +700,14 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_plus_offset_format() {
-        // Anthropic API returns "+00:00" not "Z" — format_time_until must handle it
-        // Use a far-future timestamp so this test is stable regardless of when it runs
-        let result = format_time_until("2099-01-01T00:00:00+00:00");
-        assert_ne!(result, "?", "should parse +00:00 format, not return '?'");
-        assert_ne!(
-            result, "now",
-            "far-future +00:00 timestamp should not be 'now'"
-        );
+    fn test_resolve_epoch_from_iso_plus_offset() {
+        // Anthropic API returns "+00:00" not "Z" — resolve_epoch must handle it
+        let epoch = resolve_epoch(None, "2099-01-01T00:00:00+00:00");
+        assert!(epoch.is_some(), "should parse +00:00 format");
+        let now = now_secs();
+        let result = format_reset(epoch, now);
+        assert_ne!(result, "?");
+        assert_ne!(result, "now");
     }
 
     // ── format_output() tests ─────────────────────────────────────────────────
@@ -863,26 +715,7 @@ mod tests {
     #[test]
     fn test_format_output_default_produces_legacy_format() {
         // AC1: no config → identical to old hardcoded string
-        let data = UsageLimitsData {
-            five_hour_pct: 23.4,
-            seven_day_pct: 45.1,
-            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
-            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
-        };
+        let data = sample_data();
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
         assert!(result.starts_with("5h: 23%"), "5h prefix: {result:?}");
@@ -898,20 +731,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("⏱: {pct}%({reset})".into()),
@@ -932,20 +752,7 @@ mod tests {
             seven_day_pct: 45.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             seven_day_format: Some("7d {pct}%/{reset}".into()),
@@ -966,20 +773,7 @@ mod tests {
             seven_day_pct: 20.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             separator: Some(" — ".into()),
@@ -1004,20 +798,7 @@ mod tests {
             seven_day_pct: 50.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -1039,20 +820,7 @@ mod tests {
             seven_day_pct: 10.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -1346,20 +1114,7 @@ mod tests {
             seven_day_pct: 99.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript, &cache_data, 60);
 
@@ -1406,20 +1161,16 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_epoch_past_returns_now() {
-        // A past epoch (e.g., Unix epoch 0) should return "now"
-        assert_eq!(format_time_until_epoch(0), "now");
-        assert_eq!(format_time_until_epoch(1), "now");
+    fn test_format_reset_epoch_past_returns_now() {
+        let now = now_secs();
+        assert_eq!(format_reset(Some(0), now), "now");
+        assert_eq!(format_reset(Some(1), now), "now");
     }
 
     #[test]
-    fn test_format_time_until_epoch_hours_minutes() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let future_epoch = now + 4 * 3600 + 12 * 60 + 30; // ~4h12m from now
-        let result = format_time_until_epoch(future_epoch);
+    fn test_format_reset_epoch_hours_minutes() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 4 * 3600 + 12 * 60 + 30), now);
         assert!(
             result.contains('h') && result.contains('m'),
             "expected Xh Ym format: {result}"
@@ -1427,13 +1178,9 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_epoch_days_hours() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let future_epoch = now + 3 * 86400 + 2 * 3600 + 30; // ~3d2h from now
-        let result = format_time_until_epoch(future_epoch);
+    fn test_format_reset_epoch_days_hours() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 3 * 86400 + 2 * 3600 + 30), now);
         assert!(
             result.contains('d') && result.contains('h'),
             "expected Xd Yh format: {result}"
@@ -1441,13 +1188,9 @@ mod tests {
     }
 
     #[test]
-    fn test_format_time_until_epoch_minutes_only() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let future_epoch = now + 45 * 60 + 30; // ~45m from now
-        let result = format_time_until_epoch(future_epoch);
+    fn test_format_reset_epoch_minutes_only() {
+        let now = now_secs();
+        let result = format_reset(Some(now + 45 * 60 + 30), now);
         assert!(
             result.ends_with('m') && !result.contains('h'),
             "expected Xm format: {result}"
@@ -1458,46 +1201,31 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_headroom() {
-        let now_epoch = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let resets_at_epoch = now_epoch + 9000; // 50% elapsed of 5h
-        let pace = calculate_pace(30.0, Some(resets_at_epoch), 18000);
+        let now = now_secs();
+        let pace = calculate_pace(30.0, Some(now + 9000), 18000, now);
         let p = pace.unwrap();
         assert!(p > 15.0 && p < 25.0, "expected ~+20 headroom, got {p}");
     }
 
     #[test]
     fn test_calculate_pace_over_pace() {
-        let now_epoch = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let resets_at_epoch = now_epoch + 9000;
-        let pace = calculate_pace(70.0, Some(resets_at_epoch), 18000);
+        let now = now_secs();
+        let pace = calculate_pace(70.0, Some(now + 9000), 18000, now);
         let p = pace.unwrap();
         assert!(p < -15.0 && p > -25.0, "expected ~-20 over-pace, got {p}");
     }
 
     #[test]
     fn test_calculate_pace_no_reset_returns_none() {
-        let pace = calculate_pace(50.0, None, 18000);
+        let pace = calculate_pace(50.0, None, 18000, now_secs());
         assert!(pace.is_none());
     }
 
     #[test]
     fn test_calculate_pace_zero_elapsed() {
-        // Window just started — resets_at is exactly window_secs in the future.
-        // expected_pct ≈ 0%, so pace ≈ -used_pct.
-        let now_epoch = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let resets_at_epoch = now_epoch + 18000; // full 5h remaining
-        let pace = calculate_pace(10.0, Some(resets_at_epoch), 18000);
+        let now = now_secs();
+        let pace = calculate_pace(10.0, Some(now + 18000), 18000, now);
         let p = pace.unwrap();
-        // elapsed ≈ 0, expected_pct ≈ 0, pace ≈ 0 - 10 = -10
         assert!(
             p > -15.0 && p < -5.0,
             "expected ~-10 over-pace at zero elapsed, got {p}"
@@ -1506,11 +1234,8 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_reset_in_past() {
-        let now_epoch = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let pace = calculate_pace(30.0, Some(now_epoch.saturating_sub(100)), 18000);
+        let now = now_secs();
+        let pace = calculate_pace(30.0, Some(now.saturating_sub(100)), 18000, now);
         let p = pace.unwrap();
         assert!(p > 65.0 && p < 75.0, "expected ~+70 headroom, got {p}");
     }
@@ -1548,22 +1273,9 @@ mod tests {
         let data = UsageLimitsData {
             five_hour_pct: 30.0,
             seven_day_pct: 10.0,
-            five_hour_resets_at: String::new(),
-            seven_day_resets_at: String::new(),
             five_hour_resets_at_epoch: Some(now_epoch + 9000),
             seven_day_resets_at_epoch: Some(now_epoch + 302400),
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("5h {pct}% pace:{pace}".into()),
@@ -1583,22 +1295,7 @@ mod tests {
         let data = UsageLimitsData {
             five_hour_pct: 30.0,
             seven_day_pct: 10.0,
-            five_hour_resets_at: String::new(),
-            seven_day_resets_at: String::new(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("5h {pct}% pace:{pace}".into()),
@@ -1621,20 +1318,11 @@ mod tests {
             seven_day_pct: 50.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
             extra_usage_enabled: Some(true),
             extra_usage_monthly_limit: Some(20000.0),
             extra_usage_used_credits: Some(6195.0),
             extra_usage_utilization: Some(31.0),
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -1660,20 +1348,11 @@ mod tests {
             seven_day_pct: 20.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
             extra_usage_enabled: Some(false),
             extra_usage_monthly_limit: Some(20000.0),
             extra_usage_used_credits: Some(0.0),
             extra_usage_utilization: Some(0.0),
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
@@ -1690,20 +1369,7 @@ mod tests {
             seven_day_pct: 20.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
@@ -1720,20 +1386,11 @@ mod tests {
             seven_day_pct: 50.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
             extra_usage_enabled: Some(true),
             extra_usage_monthly_limit: Some(20000.0),
             extra_usage_used_credits: Some(6195.0),
             extra_usage_utilization: Some(31.0),
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -1758,20 +1415,11 @@ mod tests {
             seven_day_pct: 30.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
             seven_day_opus_pct: Some(12.0),
             seven_day_opus_resets_at: Some("2099-02-01T00:00:00Z".into()),
             seven_day_sonnet_pct: Some(3.0),
             seven_day_sonnet_resets_at: Some("2099-03-01T00:00:00Z".into()),
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -1801,20 +1449,9 @@ mod tests {
             seven_day_pct: 30.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
             seven_day_opus_pct: Some(12.0),
             seven_day_opus_resets_at: Some("2099-02-01T00:00:00Z".into()),
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -1836,20 +1473,7 @@ mod tests {
             seven_day_pct: 30.0,
             five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
-            five_hour_resets_at_epoch: None,
-            seven_day_resets_at_epoch: None,
-            extra_usage_enabled: None,
-            extra_usage_monthly_limit: None,
-            extra_usage_used_credits: None,
-            extra_usage_utilization: None,
-            seven_day_opus_pct: None,
-            seven_day_opus_resets_at: None,
-            seven_day_sonnet_pct: None,
-            seven_day_sonnet_resets_at: None,
-            seven_day_cowork_pct: None,
-            seven_day_cowork_resets_at: None,
-            seven_day_oauth_apps_pct: None,
-            seven_day_oauth_apps_resets_at: None,
+            ..Default::default()
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -11,75 +11,203 @@ use crate::config::{CshipConfig, UsageLimitsConfig};
 use crate::context::Context;
 use crate::usage_limits::UsageLimitsData;
 
-/// Render the usage limits module.
+/// Shared data-fetch logic for the usage limits module and its sub-field renderers.
 ///
-/// Render flow (exact order):
-/// 1. Check disabled flag — silent None
-/// 2. Extract transcript_path — silent None if absent
-/// 3. Cache hit → render immediately, no thread
-/// 4. Cache miss → get OAuth token, dispatch fetch thread, recv_timeout(2s)
-/// 5. Format output
-/// 6. Apply threshold styling (higher of two pcts)
-pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+/// Stdin `rate_limits` always provides the freshest 5h/7d values (sent every render
+/// by Claude Code). Cache/OAuth provide per-model + extra usage data.
+///
+/// Strategy:
+/// 1. Start with stdin 5h/7d data (always freshest)
+/// 2. Enrich with per-model + extra usage from cache or OAuth
+/// 3. If OAuth fails, merge stdin with stale cache for per-model/extra
+/// 4. If no cache at all, return stdin-only (no per-model/extra)
+fn resolve_data(ctx: &Context, cfg: &CshipConfig) -> Option<UsageLimitsData> {
     let ul_cfg = cfg.usage_limits.as_ref();
 
-    // Step 1: disabled flag → silent None
     if ul_cfg.and_then(|c| c.disabled) == Some(true) {
         return None;
     }
 
-    // Step 2: try to use rate_limits from stdin (Claude Code sends this directly)
-    let data = if let Some(from_stdin) = data_from_stdin_rate_limits(ctx) {
-        from_stdin
-    } else {
-        // Step 3: fall back to cache / OAuth API fetch
-        let transcript_str = ctx.transcript_path.as_deref()?;
-        let transcript_path = std::path::Path::new(transcript_str);
+    let transcript_path = ctx.transcript_path.as_deref().map(std::path::Path::new);
 
-        if let Some(cached) = cache::read_usage_limits(transcript_path, false) {
-            cached
-        } else {
-            let token = match crate::platform::get_oauth_token() {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!("cship.usage_limits: credential retrieval failed: {e}");
-                    return None;
-                }
-            };
+    // Stdin provides the freshest 5h/7d values
+    let stdin_data = data_from_stdin_rate_limits(ctx);
 
-            let ttl_secs = ul_cfg.and_then(|c| c.ttl).unwrap_or(60);
+    // Try to get full data (per-model + extra) from cache or OAuth
+    let full_data = transcript_path.and_then(|tp| {
+        // Fresh cache?
+        if let Some(cached) = cache::read_usage_limits(tp, false) {
+            return Some(cached);
+        }
+        // OAuth fetch?
+        if let Some(fresh) = fetch_and_cache(tp, ul_cfg) {
+            return Some(fresh);
+        }
+        // Stale cache as last resort for per-model/extra
+        cache::read_usage_limits(tp, true)
+    });
 
-            match fetch_with_timeout(move || crate::usage_limits::fetch_usage_limits(&token)) {
-                Some(fresh) => {
-                    cache::write_usage_limits(transcript_path, &fresh, ttl_secs);
-                    fresh
-                }
-                None => cache::read_usage_limits(transcript_path, true)?,
-            }
+    match (stdin_data, full_data) {
+        // Merge: stdin 5h/7d (fresh) + cache/OAuth per-model/extra
+        (Some(stdin), Some(full)) => Some(UsageLimitsData {
+            five_hour_pct: stdin.five_hour_pct,
+            seven_day_pct: stdin.seven_day_pct,
+            five_hour_resets_at_epoch: stdin.five_hour_resets_at_epoch,
+            seven_day_resets_at_epoch: stdin.seven_day_resets_at_epoch,
+            ..full
+        }),
+        // Stdin only (no per-model/extra)
+        (Some(stdin), None) => Some(stdin),
+        // No stdin, use cache/OAuth data as-is
+        (None, Some(full)) => Some(full),
+        // Nothing available
+        (None, None) => None,
+    }
+}
+
+/// Attempt an OAuth fetch with timeout and cache the result.
+/// Returns `None` on credential failure, API error, timeout, or if a negative
+/// cache marker indicates a recent failure (30s cooldown to avoid hammering).
+fn fetch_and_cache(
+    transcript_path: &std::path::Path,
+    ul_cfg: Option<&UsageLimitsConfig>,
+) -> Option<UsageLimitsData> {
+    // Check negative cache — avoid retrying immediately after a failure
+    if cache::read_negative_marker(transcript_path) {
+        tracing::debug!("cship.usage_limits: skipping OAuth (recent failure cooldown)");
+        return None;
+    }
+
+    let token = match crate::platform::get_oauth_token() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("cship.usage_limits: credential retrieval failed: {e}");
+            cache::write_negative_marker(transcript_path, 30);
+            return None;
         }
     };
 
-    // Step 5: format output
-    let default_ul_cfg = UsageLimitsConfig::default();
-    let content = format_output(&data, ul_cfg.unwrap_or(&default_ul_cfg));
+    let ttl_secs = ul_cfg.and_then(|c| c.ttl).unwrap_or(60);
 
-    // Step 6: threshold styling — use higher of the two utilization percentages
+    match fetch_with_timeout(move || crate::usage_limits::fetch_usage_limits(&token)) {
+        Some(fresh) => {
+            cache::write_usage_limits(transcript_path, &fresh, ttl_secs);
+            Some(fresh)
+        }
+        None => {
+            cache::write_negative_marker(transcript_path, 30);
+            None
+        }
+    }
+}
+
+/// Apply threshold styling using the higher of 5h/7d utilization.
+fn apply_threshold(content: &str, data: &UsageLimitsData, cfg: &CshipConfig) -> String {
+    let ul_cfg = cfg.usage_limits.as_ref();
     let max_pct = data.five_hour_pct.max(data.seven_day_pct);
-    let style = ul_cfg.and_then(|c| c.style.as_deref());
-    let warn_threshold = ul_cfg.and_then(|c| c.warn_threshold);
-    let warn_style = ul_cfg.and_then(|c| c.warn_style.as_deref());
-    let critical_threshold = ul_cfg.and_then(|c| c.critical_threshold);
-    let critical_style = ul_cfg.and_then(|c| c.critical_style.as_deref());
-
-    Some(crate::ansi::apply_style_with_threshold(
-        &content,
+    crate::ansi::apply_style_with_threshold(
+        content,
         Some(max_pct),
-        style,
-        warn_threshold,
-        warn_style,
-        critical_threshold,
-        critical_style,
-    ))
+        ul_cfg.and_then(|c| c.style.as_deref()),
+        ul_cfg.and_then(|c| c.warn_threshold),
+        ul_cfg.and_then(|c| c.warn_style.as_deref()),
+        ul_cfg.and_then(|c| c.critical_threshold),
+        ul_cfg.and_then(|c| c.critical_style.as_deref()),
+    )
+}
+
+/// Render the usage limits module (5h + 7d + per-model + extra usage combined).
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let data = resolve_data(ctx, cfg)?;
+    let default_ul_cfg = UsageLimitsConfig::default();
+    let ul_cfg = cfg.usage_limits.as_ref().unwrap_or(&default_ul_cfg);
+    let content = format_output(&data, ul_cfg);
+    Some(apply_threshold(&content, &data, cfg))
+}
+
+/// Render only the per-model breakdown (opus, sonnet, cowork, oauth_apps).
+pub fn render_per_model(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let data = resolve_data(ctx, cfg)?;
+    let default_ul_cfg = UsageLimitsConfig::default();
+    let ul_cfg = cfg.usage_limits.as_ref().unwrap_or(&default_ul_cfg);
+    let content = format_per_model(&data, ul_cfg);
+    if content.is_empty() {
+        return None;
+    }
+    Some(apply_threshold(&content, &data, cfg))
+}
+
+/// Render a single model's usage (opus, sonnet, cowork, or oauth).
+fn render_model(
+    ctx: &Context,
+    cfg: &CshipConfig,
+    name: &str,
+    pct: impl FnOnce(&UsageLimitsData) -> Option<f64>,
+    resets_at: impl FnOnce(&UsageLimitsData) -> &Option<String>,
+    fmt: impl FnOnce(&UsageLimitsConfig) -> Option<&str>,
+) -> Option<String> {
+    let data = resolve_data(ctx, cfg)?;
+    let default_ul_cfg = UsageLimitsConfig::default();
+    let ul_cfg = cfg.usage_limits.as_ref().unwrap_or(&default_ul_cfg);
+    let content = format_single_model(name, pct(&data), resets_at(&data), fmt(ul_cfg))?;
+    Some(apply_threshold(&content, &data, cfg))
+}
+
+/// Render only the opus 7-day usage.
+pub fn render_opus(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_model(
+        ctx,
+        cfg,
+        "opus",
+        |d| d.seven_day_opus_pct,
+        |d| &d.seven_day_opus_resets_at,
+        |c| c.opus_format.as_deref(),
+    )
+}
+
+/// Render only the sonnet 7-day usage.
+pub fn render_sonnet(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_model(
+        ctx,
+        cfg,
+        "sonnet",
+        |d| d.seven_day_sonnet_pct,
+        |d| &d.seven_day_sonnet_resets_at,
+        |c| c.sonnet_format.as_deref(),
+    )
+}
+
+/// Render only the cowork 7-day usage.
+pub fn render_cowork(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_model(
+        ctx,
+        cfg,
+        "cowork",
+        |d| d.seven_day_cowork_pct,
+        |d| &d.seven_day_cowork_resets_at,
+        |c| c.cowork_format.as_deref(),
+    )
+}
+
+/// Render only the oauth_apps 7-day usage.
+pub fn render_oauth_apps(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_model(
+        ctx,
+        cfg,
+        "oauth",
+        |d| d.seven_day_oauth_apps_pct,
+        |d| &d.seven_day_oauth_apps_resets_at,
+        |c| c.oauth_apps_format.as_deref(),
+    )
+}
+
+/// Render only the extra usage section.
+pub fn render_extra_usage(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let data = resolve_data(ctx, cfg)?;
+    let default_ul_cfg = UsageLimitsConfig::default();
+    let ul_cfg = cfg.usage_limits.as_ref().unwrap_or(&default_ul_cfg);
+    let content = format_extra_usage(&data, ul_cfg)?;
+    Some(apply_threshold(&content, &data, cfg))
 }
 
 /// Spawn `fetch_fn` on a new thread and wait up to 2 seconds for the result.
@@ -214,8 +342,73 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
 
     let mut parts: Vec<String> = vec![five_h_part, seven_d_part];
 
-    #[allow(clippy::type_complexity)]
-    let model_entries: &[(&str, Option<f64>, &Option<String>, Option<&str>)] = &[
+    let per_model = format_per_model(data, cfg);
+    if !per_model.is_empty() {
+        parts.push(per_model);
+    }
+
+    if let Some(extra) = format_extra_usage(data, cfg) {
+        parts.push(extra);
+    }
+
+    parts.join(sep)
+}
+
+/// Format a single model's usage into a string. Returns `None` if the model has no data.
+fn format_single_model(
+    name: &str,
+    pct: Option<f64>,
+    resets_at: &Option<String>,
+    fmt_override: Option<&str>,
+) -> Option<String> {
+    let pct = pct?;
+    let now = now_epoch();
+    const SEVEN_DAY_SECS: u64 = 604_800;
+
+    let pct_str = format!("{:.0}", pct);
+    let remaining_str = format!("{:.0}", (100.0 - pct).max(0.0));
+    let model_epoch = resets_at
+        .as_ref()
+        .and_then(|s| crate::cache::iso8601_to_epoch(s));
+    let reset_str = match model_epoch {
+        Some(_) => format_reset(model_epoch, now),
+        None => "?".to_string(),
+    };
+    let pace_str = format_pace(calculate_pace(pct, model_epoch, SEVEN_DAY_SECS, now));
+    let default_fmt;
+    let fmt: &str = match fmt_override {
+        Some(f) => f,
+        None => {
+            default_fmt = format!("{name} {{pct}}%");
+            &default_fmt
+        }
+    };
+    Some(
+        fmt.replace("{pct}", &pct_str)
+            .replace("{remaining}", &remaining_str)
+            .replace("{reset}", &reset_str)
+            .replace("{pace}", &pace_str),
+    )
+}
+
+/// Format the per-model breakdown (opus, sonnet, cowork, oauth_apps).
+/// Returns an empty string when no per-model data is present.
+fn format_per_model(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
+    let sep = cfg.separator.as_deref().unwrap_or(" | ");
+    let parts: Vec<String> = model_entries(data, cfg)
+        .into_iter()
+        .filter_map(|(name, pct, resets_at, fmt)| format_single_model(name, pct, resets_at, fmt))
+        .collect();
+    parts.join(sep)
+}
+
+/// Return the list of (name, pct, resets_at, format_override) for all per-model entries.
+#[allow(clippy::type_complexity)]
+fn model_entries<'a>(
+    data: &'a UsageLimitsData,
+    cfg: &'a UsageLimitsConfig,
+) -> Vec<(&'a str, Option<f64>, &'a Option<String>, Option<&'a str>)> {
+    vec![
         (
             "opus",
             data.seven_day_opus_pct,
@@ -240,70 +433,53 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
             &data.seven_day_oauth_apps_resets_at,
             cfg.oauth_apps_format.as_deref(),
         ),
-    ];
+    ]
+}
 
-    for (name, pct_opt, resets_at_opt, fmt_opt) in model_entries {
-        if let Some(pct) = pct_opt {
-            let pct_str = format!("{:.0}", pct);
-            let remaining_str = format!("{:.0}", (100.0 - pct).max(0.0));
-            let model_epoch = resets_at_opt
-                .as_ref()
-                .and_then(|s| crate::cache::iso8601_to_epoch(s));
-            let reset_str = match model_epoch {
-                Some(_) => format_reset(model_epoch, now),
-                None => "?".to_string(),
-            };
-            let pace_str = format_pace(calculate_pace(*pct, model_epoch, SEVEN_DAY_SECS, now));
-            let default_fmt;
-            let fmt: &str = match fmt_opt {
-                Some(f) => f,
-                None => {
-                    default_fmt = format!("{name} {{pct}}%");
-                    &default_fmt
-                }
-            };
-            let rendered = fmt
-                .replace("{pct}", &pct_str)
-                .replace("{remaining}", &remaining_str)
-                .replace("{reset}", &reset_str)
-                .replace("{pace}", &pace_str);
-            parts.push(rendered);
-        }
+/// Format the extra usage section. Returns `None` when extra usage is absent or disabled.
+///
+/// The `{active}` placeholder renders `"⚡"` when either 5h or 7d utilization is at 100%
+/// (meaning requests are currently consuming extra credits), or `"💤"` otherwise.
+fn format_extra_usage(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> Option<String> {
+    if data.extra_usage_enabled != Some(true) {
+        return None;
     }
-
-    if data.extra_usage_enabled == Some(true) {
-        let eu_pct = data
-            .extra_usage_utilization
-            .map(|v| format!("{:.0}", v))
-            .unwrap_or_else(|| "?".into());
-        let eu_used = data
-            .extra_usage_used_credits
-            .map(|v| format!("{:.0}", v))
-            .unwrap_or_else(|| "?".into());
-        let eu_limit = data
-            .extra_usage_monthly_limit
-            .map(|v| format!("{:.0}", v))
-            .unwrap_or_else(|| "?".into());
-        let eu_remaining = match (
-            data.extra_usage_monthly_limit,
-            data.extra_usage_used_credits,
-        ) {
-            (Some(limit), Some(used)) => format!("{:.0}", (limit - used).max(0.0)),
-            _ => "?".into(),
-        };
-        let eu_fmt = cfg
-            .extra_usage_format
-            .as_deref()
-            .unwrap_or("extra: {pct}% (${used}/${limit})");
-        let rendered = eu_fmt
+    let eu_pct = data
+        .extra_usage_utilization
+        .map(|v| format!("{:.0}", v))
+        .unwrap_or_else(|| "?".into());
+    let eu_used = data
+        .extra_usage_used_credits
+        .map(|v| format!("{:.2}", v / 100.0))
+        .unwrap_or_else(|| "?".into());
+    let eu_limit = data
+        .extra_usage_monthly_limit
+        .map(|v| format!("{:.0}", v / 100.0))
+        .unwrap_or_else(|| "?".into());
+    let eu_remaining = match (
+        data.extra_usage_monthly_limit,
+        data.extra_usage_used_credits,
+    ) {
+        (Some(limit), Some(used)) => format!("{:.2}", (limit - used).max(0.0) / 100.0),
+        _ => "?".into(),
+    };
+    let active = if data.five_hour_pct >= 100.0 || data.seven_day_pct >= 100.0 {
+        "\u{26a1}" // ⚡
+    } else {
+        "\u{1f4a4}" // 💤
+    };
+    let eu_fmt = cfg
+        .extra_usage_format
+        .as_deref()
+        .unwrap_or("{active} extra: {pct}% (${used}/${limit})");
+    Some(
+        eu_fmt
+            .replace("{active}", active)
             .replace("{pct}", &eu_pct)
             .replace("{used}", &eu_used)
             .replace("{limit}", &eu_limit)
-            .replace("{remaining}", &eu_remaining);
-        parts.push(rendered);
-    }
-
-    parts.join(sep)
+            .replace("{remaining}", &eu_remaining),
+    )
 }
 
 fn now_epoch() -> u64 {
@@ -1334,9 +1510,42 @@ mod tests {
             result.contains("extra:"),
             "extra usage default format in: {result:?}"
         );
+        assert!(
+            result.contains('\u{26a1}'),
+            "active indicator (⚡) when 5h at 100%: {result:?}"
+        );
         assert!(result.contains("31%"), "extra pct in: {result:?}");
-        assert!(result.contains("6195"), "used credits in: {result:?}");
-        assert!(result.contains("20000"), "monthly limit in: {result:?}");
+        assert!(result.contains("61.95"), "used credits in: {result:?}");
+        assert!(result.contains("200"), "monthly limit in: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_extra_usage_inactive() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 40.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(1000.0),
+            extra_usage_utilization: Some(5.0),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(
+            result.contains('\u{1f4a4}'),
+            "inactive indicator (💤) when not rate-limited: {result:?}"
+        );
+        assert!(
+            !result.contains('\u{26a1}'),
+            "should not contain ⚡ when not rate-limited: {result:?}"
+        );
     }
 
     #[test]
@@ -1399,7 +1608,7 @@ mod tests {
         let result = format_output(&data, &cfg);
         assert!(result.contains("EXTRA 31%"), "custom format: {result:?}");
         assert!(
-            result.contains("rem:13805"),
+            result.contains("rem:138.05"),
             "remaining credits: {result:?}"
         );
     }

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -146,6 +146,19 @@ fn data_from_stdin_rate_limits(ctx: &Context) -> Option<UsageLimitsData> {
         seven_day_resets_at: String::new(),
         five_hour_resets_at_epoch: five_epoch,
         seven_day_resets_at_epoch: seven_epoch,
+        // Extra usage and per-model fields are only populated on the OAuth path.
+        extra_usage_enabled: None,
+        extra_usage_monthly_limit: None,
+        extra_usage_used_credits: None,
+        extra_usage_utilization: None,
+        seven_day_opus_pct: None,
+        seven_day_opus_resets_at: None,
+        seven_day_sonnet_pct: None,
+        seven_day_sonnet_resets_at: None,
+        seven_day_cowork_pct: None,
+        seven_day_cowork_resets_at: None,
+        seven_day_oauth_apps_pct: None,
+        seven_day_oauth_apps_resets_at: None,
     })
 }
 
@@ -334,6 +347,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -359,6 +384,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -392,6 +429,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -430,6 +479,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -468,6 +529,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
         // Verify read_usage_limits(allow_stale=true) works even after TTL would normally expire
@@ -488,6 +561,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cloned = expected.clone();
         let result = fetch_with_timeout(move || Ok(cloned));
@@ -513,6 +598,18 @@ mod tests {
                 seven_day_resets_at: String::new(),
                 five_hour_resets_at_epoch: None,
                 seven_day_resets_at_epoch: None,
+                extra_usage_enabled: None,
+                extra_usage_monthly_limit: None,
+                extra_usage_used_credits: None,
+                extra_usage_utilization: None,
+                seven_day_opus_pct: None,
+                seven_day_opus_resets_at: None,
+                seven_day_sonnet_pct: None,
+                seven_day_sonnet_resets_at: None,
+                seven_day_cowork_pct: None,
+                seven_day_cowork_resets_at: None,
+                seven_day_oauth_apps_pct: None,
+                seven_day_oauth_apps_resets_at: None,
             })
         });
         assert!(result.is_none());
@@ -623,6 +720,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cfg = UsageLimitsConfig::default();
         let result = format_output(&data, &cfg);
@@ -641,6 +750,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("⏱: {pct}%({reset})".into()),
@@ -663,6 +784,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cfg = UsageLimitsConfig {
             seven_day_format: Some("7d {pct}%/{reset}".into()),
@@ -685,6 +818,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cfg = UsageLimitsConfig {
             separator: Some(" — ".into()),
@@ -711,6 +856,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         let cfg = UsageLimitsConfig {
             five_hour_format: Some("{pct}%".into()),
@@ -734,6 +891,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &data, 60);
 
@@ -1029,6 +1198,18 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             five_hour_resets_at_epoch: None,
             seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
         };
         crate::cache::write_usage_limits(&transcript, &cache_data, 60);
 

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -168,24 +168,46 @@ fn data_from_stdin_rate_limits(ctx: &Context) -> Option<UsageLimitsData> {
 /// - `{pct}` — percentage used as integer (e.g. `"23"`)
 /// - `{remaining}` — percentage remaining as integer (e.g. `"77"`)
 /// - `{reset}` — time-until-reset string (e.g. `"4h12m"`)
+/// - `{pace}` — signed pace string (e.g. `"+20%"`, `"-15%"`, `"?"`)
+///
+/// Per-model breakdowns (opus, sonnet, cowork, oauth_apps) are appended when
+/// the API returns non-null data. Extra usage is appended when enabled.
 ///
 /// Defaults (backwards compatible with pre-7.2 hardcoded output):
 /// - `five_hour_format`: `"5h: {pct}% resets in {reset}"`
 /// - `seven_day_format`: `"7d: {pct}% resets in {reset}"`
 /// - `separator`: `" | "`
 fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
+    let sep = cfg.separator.as_deref().unwrap_or(" | ");
+
+    // --- Five-hour part ---
     let five_h_pct = format!("{:.0}", data.five_hour_pct);
     let five_h_remaining = format!("{:.0}", (100.0 - data.five_hour_pct).max(0.0));
     let five_h_reset = match data.five_hour_resets_at_epoch {
         Some(epoch) => format_time_until_epoch(epoch),
         None => format_time_until(&data.five_hour_resets_at),
     };
+
+    // --- Seven-day part ---
     let seven_d_pct = format!("{:.0}", data.seven_day_pct);
     let seven_d_remaining = format!("{:.0}", (100.0 - data.seven_day_pct).max(0.0));
     let seven_d_reset = match data.seven_day_resets_at_epoch {
         Some(epoch) => format_time_until_epoch(epoch),
         None => format_time_until(&data.seven_day_resets_at),
     };
+
+    // --- Pace calculation ---
+    const FIVE_HOUR_SECS: u64 = 18_000;
+    const SEVEN_DAY_SECS: u64 = 604_800;
+
+    let five_h_resets_epoch = data.five_hour_resets_at_epoch.or_else(|| {
+        crate::cache::iso8601_to_epoch(&data.five_hour_resets_at)
+    });
+    let seven_d_resets_epoch = data.seven_day_resets_at_epoch.or_else(|| {
+        crate::cache::iso8601_to_epoch(&data.seven_day_resets_at)
+    });
+    let five_h_pace = format_pace(calculate_pace(data.five_hour_pct, five_h_resets_epoch, FIVE_HOUR_SECS));
+    let seven_d_pace = format_pace(calculate_pace(data.seven_day_pct, seven_d_resets_epoch, SEVEN_DAY_SECS));
 
     let five_h_fmt = cfg
         .five_hour_format
@@ -195,18 +217,69 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
         .seven_day_format
         .as_deref()
         .unwrap_or("7d: {pct}% resets in {reset}");
-    let sep = cfg.separator.as_deref().unwrap_or(" | ");
 
     let five_h_part = five_h_fmt
         .replace("{pct}", &five_h_pct)
         .replace("{remaining}", &five_h_remaining)
-        .replace("{reset}", &five_h_reset);
+        .replace("{reset}", &five_h_reset)
+        .replace("{pace}", &five_h_pace);
     let seven_d_part = seven_d_fmt
         .replace("{pct}", &seven_d_pct)
         .replace("{remaining}", &seven_d_remaining)
-        .replace("{reset}", &seven_d_reset);
+        .replace("{reset}", &seven_d_reset)
+        .replace("{pace}", &seven_d_pace);
 
-    format!("{five_h_part}{sep}{seven_d_part}")
+    let mut parts: Vec<String> = vec![five_h_part, seven_d_part];
+
+    // --- Per-model 7-day breakdowns ---
+    #[allow(clippy::type_complexity)]
+    let model_entries: &[(&str, Option<f64>, &Option<String>, Option<&str>)] = &[
+        ("opus", data.seven_day_opus_pct, &data.seven_day_opus_resets_at, cfg.opus_format.as_deref()),
+        ("sonnet", data.seven_day_sonnet_pct, &data.seven_day_sonnet_resets_at, cfg.sonnet_format.as_deref()),
+        ("cowork", data.seven_day_cowork_pct, &data.seven_day_cowork_resets_at, cfg.cowork_format.as_deref()),
+        ("oauth", data.seven_day_oauth_apps_pct, &data.seven_day_oauth_apps_resets_at, cfg.oauth_apps_format.as_deref()),
+    ];
+
+    for (name, pct_opt, resets_at_opt, fmt_opt) in model_entries {
+        if let Some(pct) = pct_opt {
+            let pct_str = format!("{:.0}", pct);
+            let remaining_str = format!("{:.0}", (100.0 - pct).max(0.0));
+            let reset_str = match resets_at_opt {
+                Some(s) => format_time_until(s),
+                None => "?".to_string(),
+            };
+            let default_fmt = format!("{name} {{pct}}%");
+            let fmt = fmt_opt.unwrap_or(&default_fmt);
+            let rendered = fmt
+                .replace("{pct}", &pct_str)
+                .replace("{remaining}", &remaining_str)
+                .replace("{reset}", &reset_str);
+            parts.push(rendered);
+        }
+    }
+
+    // --- Extra usage ---
+    if data.extra_usage_enabled == Some(true) {
+        let eu_pct = data.extra_usage_utilization.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
+        let eu_used = data.extra_usage_used_credits.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
+        let eu_limit = data.extra_usage_monthly_limit.map(|v| format!("{:.0}", v)).unwrap_or_else(|| "?".into());
+        let eu_remaining = match (data.extra_usage_monthly_limit, data.extra_usage_used_credits) {
+            (Some(limit), Some(used)) => format!("{:.0}", (limit - used).max(0.0)),
+            _ => "?".into(),
+        };
+        let eu_fmt = cfg
+            .extra_usage_format
+            .as_deref()
+            .unwrap_or("extra: {pct}% (${used}/${limit})");
+        let rendered = eu_fmt
+            .replace("{pct}", &eu_pct)
+            .replace("{used}", &eu_used)
+            .replace("{limit}", &eu_limit)
+            .replace("{remaining}", &eu_remaining);
+        parts.push(rendered);
+    }
+
+    parts.join(sep)
 }
 
 /// Convert a Unix epoch reset timestamp to a human-readable time-until string.
@@ -272,6 +345,43 @@ fn format_remaining_secs(secs: u64) -> String {
         format!("{}h{}m", hours, mins % 60)
     } else {
         format!("{}m", mins)
+    }
+}
+
+/// Calculate pace: how far ahead or behind linear consumption the user is.
+///
+/// Returns `Some(pace)` where positive = headroom, negative = over-pace.
+/// Returns `None` when `resets_at_epoch` is unavailable.
+///
+/// - `used_pct`: current utilization percentage (0-100+)
+/// - `resets_at_epoch`: Unix epoch when the window resets; `None` = unknown
+/// - `window_secs`: total window duration in seconds (18000 for 5h, 604800 for 7d)
+fn calculate_pace(used_pct: f64, resets_at_epoch: Option<u64>, window_secs: u64) -> Option<f64> {
+    let reset = resets_at_epoch?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let remaining = reset.saturating_sub(now);
+    let elapsed = window_secs.saturating_sub(remaining);
+    let elapsed_fraction = elapsed as f64 / window_secs as f64;
+    let expected_pct = elapsed_fraction * 100.0;
+    Some(expected_pct - used_pct)
+}
+
+/// Format a pace value as a signed percentage string.
+/// Positive → "+20%", negative → "-15%", None → "?".
+fn format_pace(pace: Option<f64>) -> String {
+    match pace {
+        Some(p) => {
+            let rounded = p.round() as i64;
+            if rounded >= 0 {
+                format!("+{rounded}%")
+            } else {
+                format!("{rounded}%")
+            }
+        }
+        None => "?".to_string(),
     }
 }
 
@@ -1302,5 +1412,365 @@ mod tests {
             result.ends_with('m') && !result.contains('h'),
             "expected Xm format: {result}"
         );
+    }
+
+    // ── calculate_pace() tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_calculate_pace_headroom() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let resets_at_epoch = now_epoch + 9000; // 50% elapsed of 5h
+        let pace = calculate_pace(30.0, Some(resets_at_epoch), 18000);
+        let p = pace.unwrap();
+        assert!(p > 15.0 && p < 25.0, "expected ~+20 headroom, got {p}");
+    }
+
+    #[test]
+    fn test_calculate_pace_over_pace() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let resets_at_epoch = now_epoch + 9000;
+        let pace = calculate_pace(70.0, Some(resets_at_epoch), 18000);
+        let p = pace.unwrap();
+        assert!(p < -15.0 && p > -25.0, "expected ~-20 over-pace, got {p}");
+    }
+
+    #[test]
+    fn test_calculate_pace_no_reset_returns_none() {
+        let pace = calculate_pace(50.0, None, 18000);
+        assert!(pace.is_none());
+    }
+
+    #[test]
+    fn test_calculate_pace_reset_in_past() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let pace = calculate_pace(30.0, Some(now_epoch.saturating_sub(100)), 18000);
+        let p = pace.unwrap();
+        assert!(p > 65.0 && p < 75.0, "expected ~+70 headroom, got {p}");
+    }
+
+    // ── format_pace() tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_pace_positive() {
+        assert_eq!(format_pace(Some(20.3)), "+20%");
+    }
+
+    #[test]
+    fn test_format_pace_negative() {
+        assert_eq!(format_pace(Some(-15.7)), "-16%");
+    }
+
+    #[test]
+    fn test_format_pace_zero() {
+        assert_eq!(format_pace(Some(0.0)), "+0%");
+    }
+
+    #[test]
+    fn test_format_pace_none() {
+        assert_eq!(format_pace(None), "?");
+    }
+
+    // ── pace in format_output() tests ────────────────────────────────────────
+
+    #[test]
+    fn test_format_output_pace_placeholder_five_hour() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let data = UsageLimitsData {
+            five_hour_pct: 30.0,
+            seven_day_pct: 10.0,
+            five_hour_resets_at: String::new(),
+            seven_day_resets_at: String::new(),
+            five_hour_resets_at_epoch: Some(now_epoch + 9000),
+            seven_day_resets_at_epoch: Some(now_epoch + 302400),
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("5h {pct}% pace:{pace}".into()),
+            seven_day_format: Some("7d {pct}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("pace:+"), "expected positive pace in: {result:?}");
+        assert!(result.contains("5h 30%"), "expected 5h 30% in: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_pace_placeholder_no_epoch() {
+        let data = UsageLimitsData {
+            five_hour_pct: 30.0,
+            seven_day_pct: 10.0,
+            five_hour_resets_at: String::new(),
+            seven_day_resets_at: String::new(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("5h {pct}% pace:{pace}".into()),
+            seven_day_format: Some("7d {pct}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("pace:?"), "expected ? for unknown pace in: {result:?}");
+    }
+
+    // ── extra usage in format_output() tests ─────────────────────────────────
+
+    #[test]
+    fn test_format_output_extra_usage_enabled() {
+        let data = UsageLimitsData {
+            five_hour_pct: 100.0,
+            seven_day_pct: 50.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(6195.0),
+            extra_usage_utilization: Some(31.0),
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("100%"), "five_hour in: {result:?}");
+        assert!(result.contains("50%"), "seven_day in: {result:?}");
+        assert!(result.contains("extra:"), "extra usage default format in: {result:?}");
+        assert!(result.contains("31%"), "extra pct in: {result:?}");
+        assert!(result.contains("6195"), "used credits in: {result:?}");
+        assert!(result.contains("20000"), "monthly limit in: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_extra_usage_disabled() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 20.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: Some(false),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(0.0),
+            extra_usage_utilization: Some(0.0),
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig::default();
+        let result = format_output(&data, &cfg);
+        assert!(!result.contains("extra"), "extra usage should be hidden when disabled: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_extra_usage_absent() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 20.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig::default();
+        let result = format_output(&data, &cfg);
+        assert!(!result.contains("extra"), "extra usage should be absent: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_extra_usage_custom_format() {
+        let data = UsageLimitsData {
+            five_hour_pct: 100.0,
+            seven_day_pct: 50.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(6195.0),
+            extra_usage_utilization: Some(31.0),
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            extra_usage_format: Some("EXTRA {pct}% rem:{remaining}".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("EXTRA 31%"), "custom format: {result:?}");
+        assert!(result.contains("rem:13805"), "remaining credits: {result:?}");
+    }
+
+    // ── per-model in format_output() tests ───────────────────────────────────
+
+    #[test]
+    fn test_format_output_per_model_present() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 30.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: Some(12.0),
+            seven_day_opus_resets_at: Some("2099-02-01T00:00:00Z".into()),
+            seven_day_sonnet_pct: Some(3.0),
+            seven_day_sonnet_resets_at: Some("2099-03-01T00:00:00Z".into()),
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("opus 12%"), "opus breakdown in: {result:?}");
+        assert!(result.contains("sonnet 3%"), "sonnet breakdown in: {result:?}");
+        assert!(!result.contains("cowork"), "null cowork should be omitted: {result:?}");
+        assert!(!result.contains("oauth"), "null oauth_apps should be omitted: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_per_model_custom_format() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 30.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: Some(12.0),
+            seven_day_opus_resets_at: Some("2099-02-01T00:00:00Z".into()),
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            opus_format: Some("OP:{pct}%/{remaining}%".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(result.contains("OP:12%/88%"), "custom opus format: {result:?}");
+    }
+
+    #[test]
+    fn test_format_output_no_dangling_separators() {
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 30.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            five_hour_resets_at_epoch: None,
+            seven_day_resets_at_epoch: None,
+            extra_usage_enabled: None,
+            extra_usage_monthly_limit: None,
+            extra_usage_used_credits: None,
+            extra_usage_utilization: None,
+            seven_day_opus_pct: None,
+            seven_day_opus_resets_at: None,
+            seven_day_sonnet_pct: None,
+            seven_day_sonnet_resets_at: None,
+            seven_day_cowork_pct: None,
+            seven_day_cowork_resets_at: None,
+            seven_day_oauth_apps_pct: None,
+            seven_day_oauth_apps_resets_at: None,
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            separator: Some(" | ".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert_eq!(result, "50% | 30%", "no trailing separator: {result:?}");
+        assert!(!result.ends_with(" | "), "no dangling sep: {result:?}");
     }
 }

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -246,10 +246,14 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
         if let Some(pct) = pct_opt {
             let pct_str = format!("{:.0}", pct);
             let remaining_str = format!("{:.0}", (100.0 - pct).max(0.0));
-            let reset_str = match resets_at_opt {
-                Some(s) => format_reset(crate::cache::iso8601_to_epoch(s), now),
+            let model_epoch = resets_at_opt
+                .as_ref()
+                .and_then(|s| crate::cache::iso8601_to_epoch(s));
+            let reset_str = match model_epoch {
+                Some(_) => format_reset(model_epoch, now),
                 None => "?".to_string(),
             };
+            let pace_str = format_pace(calculate_pace(*pct, model_epoch, SEVEN_DAY_SECS, now));
             let default_fmt;
             let fmt: &str = match fmt_opt {
                 Some(f) => f,
@@ -261,7 +265,8 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
             let rendered = fmt
                 .replace("{pct}", &pct_str)
                 .replace("{remaining}", &remaining_str)
-                .replace("{reset}", &reset_str);
+                .replace("{reset}", &reset_str)
+                .replace("{pace}", &pace_str);
             parts.push(rendered);
         }
     }
@@ -648,30 +653,23 @@ mod tests {
         assert_eq!(epoch_to_iso(Some(4_102_358_400)), "2099-12-31T00:00:00Z");
     }
 
-    fn now_secs() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-    }
-
     // ── format_reset() tests ─────────────────────────────────────────────────
 
     #[test]
     fn test_format_reset_none_returns_question_mark() {
-        assert_eq!(format_reset(None, now_secs()), "?");
+        assert_eq!(format_reset(None, now_epoch()), "?");
     }
 
     #[test]
     fn test_format_reset_past_returns_now() {
-        let now = now_secs();
+        let now = now_epoch();
         assert_eq!(format_reset(Some(0), now), "now");
         assert_eq!(format_reset(Some(now.saturating_sub(1)), now), "now");
     }
 
     #[test]
     fn test_format_reset_hours_minutes() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 4 * 3600 + 12 * 60 + 30), now);
         assert!(
             result.contains('h') && result.contains('m'),
@@ -681,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_format_reset_days_hours() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 3 * 86400 + 2 * 3600 + 30), now);
         assert!(
             result.contains('d') && result.contains('h'),
@@ -691,7 +689,7 @@ mod tests {
 
     #[test]
     fn test_format_reset_minutes_only() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 45 * 60 + 30), now);
         assert!(
             result.ends_with('m') && !result.contains('h'),
@@ -704,7 +702,7 @@ mod tests {
         // Anthropic API returns "+00:00" not "Z" — resolve_epoch must handle it
         let epoch = resolve_epoch(None, "2099-01-01T00:00:00+00:00");
         assert!(epoch.is_some(), "should parse +00:00 format");
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(epoch, now);
         assert_ne!(result, "?");
         assert_ne!(result, "now");
@@ -1162,14 +1160,14 @@ mod tests {
 
     #[test]
     fn test_format_reset_epoch_past_returns_now() {
-        let now = now_secs();
+        let now = now_epoch();
         assert_eq!(format_reset(Some(0), now), "now");
         assert_eq!(format_reset(Some(1), now), "now");
     }
 
     #[test]
     fn test_format_reset_epoch_hours_minutes() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 4 * 3600 + 12 * 60 + 30), now);
         assert!(
             result.contains('h') && result.contains('m'),
@@ -1179,7 +1177,7 @@ mod tests {
 
     #[test]
     fn test_format_reset_epoch_days_hours() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 3 * 86400 + 2 * 3600 + 30), now);
         assert!(
             result.contains('d') && result.contains('h'),
@@ -1189,7 +1187,7 @@ mod tests {
 
     #[test]
     fn test_format_reset_epoch_minutes_only() {
-        let now = now_secs();
+        let now = now_epoch();
         let result = format_reset(Some(now + 45 * 60 + 30), now);
         assert!(
             result.ends_with('m') && !result.contains('h'),
@@ -1201,7 +1199,7 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_headroom() {
-        let now = now_secs();
+        let now = now_epoch();
         let pace = calculate_pace(30.0, Some(now + 9000), 18000, now);
         let p = pace.unwrap();
         assert!(p > 15.0 && p < 25.0, "expected ~+20 headroom, got {p}");
@@ -1209,7 +1207,7 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_over_pace() {
-        let now = now_secs();
+        let now = now_epoch();
         let pace = calculate_pace(70.0, Some(now + 9000), 18000, now);
         let p = pace.unwrap();
         assert!(p < -15.0 && p > -25.0, "expected ~-20 over-pace, got {p}");
@@ -1217,13 +1215,13 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_no_reset_returns_none() {
-        let pace = calculate_pace(50.0, None, 18000, now_secs());
+        let pace = calculate_pace(50.0, None, 18000, now_epoch());
         assert!(pace.is_none());
     }
 
     #[test]
     fn test_calculate_pace_zero_elapsed() {
-        let now = now_secs();
+        let now = now_epoch();
         let pace = calculate_pace(10.0, Some(now + 18000), 18000, now);
         let p = pace.unwrap();
         assert!(
@@ -1234,7 +1232,7 @@ mod tests {
 
     #[test]
     fn test_calculate_pace_reset_in_past() {
-        let now = now_secs();
+        let now = now_epoch();
         let pace = calculate_pace(30.0, Some(now.saturating_sub(100)), 18000, now);
         let p = pace.unwrap();
         assert!(p > 65.0 && p < 75.0, "expected ~+70 headroom, got {p}");
@@ -1463,6 +1461,38 @@ mod tests {
         assert!(
             result.contains("OP:12%/88%"),
             "custom opus format: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_per_model_pace_placeholder() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let data = UsageLimitsData {
+            five_hour_pct: 50.0,
+            seven_day_pct: 30.0,
+            five_hour_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
+            seven_day_opus_pct: Some(12.0),
+            seven_day_opus_resets_at: Some(epoch_to_iso(Some(now_epoch + 302_400))),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("{pct}%".into()),
+            seven_day_format: Some("{pct}%".into()),
+            opus_format: Some("opus {pct}% pace:{pace}".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(
+            !result.contains("{pace}"),
+            "literal {{pace}} should be substituted: {result:?}"
+        );
+        assert!(
+            result.contains("pace:+"),
+            "opus pace should show headroom: {result:?}"
         );
     }
 

--- a/src/usage_limits.rs
+++ b/src/usage_limits.rs
@@ -14,7 +14,7 @@
 /// Unix epoch directly). On the OAuth/cache path these fields are `None` and the ISO 8601
 /// string fields are used instead. Serde serialises `None` as `null`, which is ignored by
 /// old cache readers (backward-compatible).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct UsageLimitsData {
     pub five_hour_pct: f64,
     pub seven_day_pct: f64,

--- a/src/usage_limits.rs
+++ b/src/usage_limits.rs
@@ -26,6 +26,32 @@ pub struct UsageLimitsData {
     /// Unix epoch seconds for the seven-day window reset; `Some` only on the stdin path.
     #[serde(default)]
     pub seven_day_resets_at_epoch: Option<u64>,
+    // Extra usage (OAuth API only; absent on stdin path)
+    #[serde(default)]
+    pub extra_usage_enabled: Option<bool>,
+    #[serde(default)]
+    pub extra_usage_monthly_limit: Option<f64>,
+    #[serde(default)]
+    pub extra_usage_used_credits: Option<f64>,
+    #[serde(default)]
+    pub extra_usage_utilization: Option<f64>,
+    // Per-model 7-day breakdowns (OAuth API only)
+    #[serde(default)]
+    pub seven_day_opus_pct: Option<f64>,
+    #[serde(default)]
+    pub seven_day_opus_resets_at: Option<String>,
+    #[serde(default)]
+    pub seven_day_sonnet_pct: Option<f64>,
+    #[serde(default)]
+    pub seven_day_sonnet_resets_at: Option<String>,
+    #[serde(default)]
+    pub seven_day_cowork_pct: Option<f64>,
+    #[serde(default)]
+    pub seven_day_cowork_resets_at: Option<String>,
+    #[serde(default)]
+    pub seven_day_oauth_apps_pct: Option<f64>,
+    #[serde(default)]
+    pub seven_day_oauth_apps_resets_at: Option<String>,
 }
 
 /// Intermediate struct matching the raw API response structure.
@@ -33,12 +59,66 @@ pub struct UsageLimitsData {
 struct ApiResponse {
     five_hour: UsagePeriod,
     seven_day: UsagePeriod,
+    seven_day_opus: Option<UsagePeriod>,
+    seven_day_sonnet: Option<UsagePeriod>,
+    seven_day_cowork: Option<UsagePeriod>,
+    seven_day_oauth_apps: Option<UsagePeriod>,
+    extra_usage: Option<ExtraUsageResponse>,
 }
 
 #[derive(serde::Deserialize)]
 struct UsagePeriod {
     utilization: f64,
     resets_at: Option<String>,
+}
+
+/// Intermediate struct matching the `extra_usage` object in the API response.
+#[derive(serde::Deserialize)]
+struct ExtraUsageResponse {
+    is_enabled: Option<bool>,
+    monthly_limit: Option<f64>,
+    used_credits: Option<f64>,
+    utilization: Option<f64>,
+}
+
+/// Parse a raw JSON string into `UsageLimitsData`.
+/// Extracted from `fetch_usage_limits` for unit-testability without HTTP.
+fn parse_api_response(json: &str) -> Result<UsageLimitsData, String> {
+    let api: ApiResponse =
+        serde_json::from_str(json).map_err(|e| format!("unexpected response format: {e}"))?;
+
+    let map_period = |p: &Option<UsagePeriod>| -> (Option<f64>, Option<String>) {
+        match p {
+            Some(period) => (Some(period.utilization), period.resets_at.clone()),
+            None => (None, None),
+        }
+    };
+
+    let (opus_pct, opus_reset) = map_period(&api.seven_day_opus);
+    let (sonnet_pct, sonnet_reset) = map_period(&api.seven_day_sonnet);
+    let (cowork_pct, cowork_reset) = map_period(&api.seven_day_cowork);
+    let (oauth_apps_pct, oauth_apps_reset) = map_period(&api.seven_day_oauth_apps);
+
+    Ok(UsageLimitsData {
+        five_hour_pct: api.five_hour.utilization,
+        seven_day_pct: api.seven_day.utilization,
+        five_hour_resets_at: api.five_hour.resets_at.unwrap_or_default(),
+        seven_day_resets_at: api.seven_day.resets_at.unwrap_or_default(),
+        five_hour_resets_at_epoch: None,
+        seven_day_resets_at_epoch: None,
+        extra_usage_enabled: api.extra_usage.as_ref().and_then(|e| e.is_enabled),
+        extra_usage_monthly_limit: api.extra_usage.as_ref().and_then(|e| e.monthly_limit),
+        extra_usage_used_credits: api.extra_usage.as_ref().and_then(|e| e.used_credits),
+        extra_usage_utilization: api.extra_usage.as_ref().and_then(|e| e.utilization),
+        seven_day_opus_pct: opus_pct,
+        seven_day_opus_resets_at: opus_reset,
+        seven_day_sonnet_pct: sonnet_pct,
+        seven_day_sonnet_resets_at: sonnet_reset,
+        seven_day_cowork_pct: cowork_pct,
+        seven_day_cowork_resets_at: cowork_reset,
+        seven_day_oauth_apps_pct: oauth_apps_pct,
+        seven_day_oauth_apps_resets_at: oauth_apps_reset,
+    })
 }
 
 /// Fetch current usage limits from the Anthropic API.
@@ -63,20 +143,57 @@ pub fn fetch_usage_limits(token: &str) -> Result<UsageLimitsData, String> {
         return Err(format!("API returned {}", response.status()));
     }
 
-    let api: ApiResponse = response
+    let body = response
         .body_mut()
-        .read_json()
-        .map_err(|e| format!("unexpected response format: {e}"))?;
+        .read_to_string()
+        .map_err(|e| format!("failed to read response body: {e}"))?;
+    parse_api_response(&body)
+}
 
-    Ok(UsageLimitsData {
-        // API returns utilization as a percentage (0–100), not a fraction (0–1).
-        // Reference: https://codelynx.dev/posts/claude-code-usage-limits-statusline
-        five_hour_pct: api.five_hour.utilization,
-        seven_day_pct: api.seven_day.utilization,
-        five_hour_resets_at: api.five_hour.resets_at.unwrap_or_default(),
-        seven_day_resets_at: api.seven_day.resets_at.unwrap_or_default(),
-        // Epoch fields are only populated on the stdin path; OAuth path uses ISO strings.
-        five_hour_resets_at_epoch: None,
-        seven_day_resets_at_epoch: None,
-    })
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_parses_extra_usage_fields() {
+        let json = r#"{
+            "five_hour": {"utilization": 100.0, "resets_at": "2099-01-01T00:00:00+00:00"},
+            "seven_day": {"utilization": 47.0, "resets_at": "2099-01-01T00:00:00+00:00"},
+            "seven_day_opus": {"utilization": 12.0, "resets_at": "2099-02-01T00:00:00+00:00"},
+            "seven_day_sonnet": {"utilization": 3.0, "resets_at": "2099-03-01T00:00:00+00:00"},
+            "seven_day_cowork": null,
+            "seven_day_oauth_apps": null,
+            "extra_usage": {
+                "is_enabled": true,
+                "monthly_limit": 20000,
+                "used_credits": 6195.0,
+                "utilization": 30.975
+            },
+            "iguana_necktie": null
+        }"#;
+        let data = parse_api_response(json).unwrap();
+        assert_eq!(data.extra_usage_enabled, Some(true));
+        assert_eq!(data.extra_usage_monthly_limit, Some(20000.0));
+        assert!((data.extra_usage_used_credits.unwrap() - 6195.0).abs() < f64::EPSILON);
+        assert!((data.extra_usage_utilization.unwrap() - 30.975).abs() < f64::EPSILON);
+        assert!((data.seven_day_opus_pct.unwrap() - 12.0).abs() < f64::EPSILON);
+        assert_eq!(data.seven_day_opus_resets_at.as_deref(), Some("2099-02-01T00:00:00+00:00"));
+        assert!((data.seven_day_sonnet_pct.unwrap() - 3.0).abs() < f64::EPSILON);
+        assert_eq!(data.seven_day_sonnet_resets_at.as_deref(), Some("2099-03-01T00:00:00+00:00"));
+        assert!(data.seven_day_cowork_pct.is_none());
+        assert!(data.seven_day_oauth_apps_pct.is_none());
+    }
+
+    #[test]
+    fn test_fetch_parses_null_extra_usage() {
+        let json = r#"{
+            "five_hour": {"utilization": 50.0, "resets_at": "2099-01-01T00:00:00+00:00"},
+            "seven_day": {"utilization": 20.0, "resets_at": "2099-01-01T00:00:00+00:00"}
+        }"#;
+        let data = parse_api_response(json).unwrap();
+        assert!(data.extra_usage_enabled.is_none());
+        assert!(data.extra_usage_monthly_limit.is_none());
+        assert!(data.seven_day_opus_pct.is_none());
+        assert!(data.seven_day_sonnet_pct.is_none());
+    }
 }

--- a/src/usage_limits.rs
+++ b/src/usage_limits.rs
@@ -177,9 +177,15 @@ mod tests {
         assert!((data.extra_usage_used_credits.unwrap() - 6195.0).abs() < f64::EPSILON);
         assert!((data.extra_usage_utilization.unwrap() - 30.975).abs() < f64::EPSILON);
         assert!((data.seven_day_opus_pct.unwrap() - 12.0).abs() < f64::EPSILON);
-        assert_eq!(data.seven_day_opus_resets_at.as_deref(), Some("2099-02-01T00:00:00+00:00"));
+        assert_eq!(
+            data.seven_day_opus_resets_at.as_deref(),
+            Some("2099-02-01T00:00:00+00:00")
+        );
         assert!((data.seven_day_sonnet_pct.unwrap() - 3.0).abs() < f64::EPSILON);
-        assert_eq!(data.seven_day_sonnet_resets_at.as_deref(), Some("2099-03-01T00:00:00+00:00"));
+        assert_eq!(
+            data.seven_day_sonnet_resets_at.as_deref(),
+            Some("2099-03-01T00:00:00+00:00")
+        );
         assert!(data.seven_day_cowork_pct.is_none());
         assert!(data.seven_day_oauth_apps_pct.is_none());
     }


### PR DESCRIPTION
## Summary

- **Extra usage rendering**: parse `extra_usage` from the OAuth API (enabled flag, monthly limit, used credits, utilization) and render it with a configurable `extra_usage_format`. Credits are converted from cents to dollars for `{used}`/`{limit}` placeholders.
- **Per-model 7-day breakdowns**: parse and render per-model utilization (opus, sonnet, cowork, oauth_apps) with configurable format strings (`opus_format`, `sonnet_format`, etc.)
- **Pace tracking**: `{pace}` placeholder in all format strings shows signed headroom vs linear consumption (e.g. `+20%`, `-15%`)
- **Sub-field renderers**: each section is available as an independent token (`$cship.usage_limits.opus`, `$cship.usage_limits.extra_usage`, etc.) so users can compose their statusline layout freely — e.g. put per-model on a separate line from the main 5h/7d display
- **`{active}` indicator**: extra usage format supports an `{active}` placeholder — renders ⚡ when 5h or 7d is at 100% (actively consuming extra credits), 💤 otherwise
- **Hybrid data resolution**: stdin `rate_limits` always provides the freshest 5h/7d values; cache/OAuth provides per-model and extra usage. The two are merged so the statusline shows both real-time utilization and the full breakdown.
- **Negative cache**: 30-second cooldown marker after OAuth failures prevents hammering the API on repeated render cycles

Related: #150 (sub-field renderers address independent formatting of composite sub-values for usage_limits)

> I don't want to overwhelm with a large PR — I just found these useful for my own workflow and thought others might benefit too. Happy to split this up or adjust the approach if you'd prefer something different.

## Test plan

- [x] `cargo fmt` — passes
- [x] `cargo clippy -- -D warnings` — passes
- [x] `cargo test` — 346 unit + 66 integration tests pass (includes new tests for extra usage, per-model, pace, {active}, negative cache, hybrid resolve, and backwards-compat)
- [x] `cargo build --release` — builds successfully