### PR TITLE
feat(context_bar): add configurable filled_char and empty_char

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,8 @@ Renders a visual ASCII progress bar showing context window usage.
 | `symbol` | `string` | `""` | Prefix symbol |
 | `format` | `string` | `"[$symbol$value]($style)"` | Format string |
 | `width` | `integer` | `10` | Number of characters in the bar |
+| `filled_char` | `string` | `"█"` | Character used for the filled portion. Any Unicode character is allowed. |
+| `empty_char` | `string` | `"░"` | Character used for the empty portion. Any Unicode character is allowed. |
 | `warn_threshold` | `float` | — | % at which style switches to `warn_style` |
 | `warn_style` | `string` | `"yellow"` | Style at warn level |
 | `critical_threshold` | `float` | — | % at which style switches to `critical_style` |
@@ -171,6 +173,14 @@ warn_threshold     = 40.0
 warn_style         = "yellow"
 critical_threshold = 70.0
 critical_style     = "bold red"
+```
+
+For a circle-style bar (`●●●●○○○○○○40%`):
+
+```toml
+[cship.context_bar]
+filled_char = "●"
+empty_char  = "○"
 ```
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,12 @@ pub struct ContextBarConfig {
     /// Style applied when rendering the bar at 0% due to absent context data.
     /// Example: `"dim"` to visually distinguish the empty state.
     pub empty_style: Option<String>,
+    /// Character used for filled (used) slots. Defaults to `"█"`.
+    /// Example: `"●"` for filled circles.
+    pub filled_char: Option<String>,
+    /// Character used for empty (unused) slots. Defaults to `"░"`.
+    /// Example: `"○"` for hollow circles.
+    pub empty_char: Option<String>,
 }
 
 /// Configuration for `[cship.context_window]` sub-field modules.

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -2,10 +2,13 @@ use crate::config::CshipConfig;
 use crate::context::Context;
 
 const DEFAULT_BAR_WIDTH: u32 = 10;
+const DEFAULT_FILLED_CHAR: &str = "█";
+const DEFAULT_EMPTY_CHAR: &str = "░";
 
 /// Renders `$cship.context_bar` — visual Unicode progress bar with threshold color escalation.
 /// Format: `{bar}{used_percentage:.0}%` e.g. `███░░░░░░░35%`
 /// Bar width is configurable via `[cship.context_bar].width` (default 10).
+/// Fill characters are configurable via `filled_char` (default `"█"`) and `empty_char` (default `"░"`).
 ///
 /// Source: epics.md#Story 2.2, prd.md#FR8
 pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
@@ -36,7 +39,9 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let filled = filled.min(width); // guard floating-point edge at 100%
     let empty = width - filled;
 
-    let bar: String = "█".repeat(filled) + &"░".repeat(empty);
+    let filled_char = bar_cfg.and_then(|c| c.filled_char.as_deref()).unwrap_or(DEFAULT_FILLED_CHAR);
+    let empty_char = bar_cfg.and_then(|c| c.empty_char.as_deref()).unwrap_or(DEFAULT_EMPTY_CHAR);
+    let bar: String = filled_char.repeat(filled) + &empty_char.repeat(empty);
     let bar_content = format!("{bar}{:.0}%", used_pct);
 
     let symbol = bar_cfg.and_then(|c| c.symbol.as_deref());
@@ -400,5 +405,42 @@ mod tests {
             warn_result, crit_result,
             "warn and critical styles must produce different output"
         );
+    }
+
+    #[test]
+    fn test_context_bar_custom_filled_and_empty_chars() {
+        let ctx = ctx_with_pct(40.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                filled_char: Some("●".to_string()),
+                empty_char: Some("○".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        // 40% of 10 = 4 filled, 6 empty
+        let filled: usize = result.chars().filter(|&c| c == '●').count();
+        let empty: usize = result.chars().filter(|&c| c == '○').count();
+        assert_eq!(filled, 4, "expected 4 filled circles: {result:?}");
+        assert_eq!(empty, 6, "expected 6 empty circles: {result:?}");
+        assert!(result.contains("40%"), "expected '40%' in: {result:?}");
+    }
+
+    #[test]
+    fn test_context_bar_only_filled_char_overridden() {
+        let ctx = ctx_with_pct(50.0);
+        let cfg = CshipConfig {
+            context_bar: Some(ContextBarConfig {
+                filled_char: Some("●".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        let filled: usize = result.chars().filter(|&c| c == '●').count();
+        let empty: usize = result.chars().filter(|&c| c == '░').count();
+        assert_eq!(filled, 5, "expected 5 filled circles: {result:?}");
+        assert_eq!(empty, 5, "expected 5 default empty chars: {result:?}");
     }
 }

--- a/src/modules/context_bar.rs
+++ b/src/modules/context_bar.rs
@@ -39,8 +39,12 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let filled = filled.min(width); // guard floating-point edge at 100%
     let empty = width - filled;
 
-    let filled_char = bar_cfg.and_then(|c| c.filled_char.as_deref()).unwrap_or(DEFAULT_FILLED_CHAR);
-    let empty_char = bar_cfg.and_then(|c| c.empty_char.as_deref()).unwrap_or(DEFAULT_EMPTY_CHAR);
+    let filled_char = bar_cfg
+        .and_then(|c| c.filled_char.as_deref())
+        .unwrap_or(DEFAULT_FILLED_CHAR);
+    let empty_char = bar_cfg
+        .and_then(|c| c.empty_char.as_deref())
+        .unwrap_or(DEFAULT_EMPTY_CHAR);
     let bar: String = filled_char.repeat(filled) + &empty_char.repeat(empty);
     let bar_content = format!("{bar}{:.0}%", used_pct);
 


### PR DESCRIPTION
## Summary

- Adds `filled_char` and `empty_char` fields to `[cship.context_bar]` config
- Defaults to `█` / `░` for full backwards compatibility
- Allows any Unicode character, enabling circle-style or custom bars

## Motivation

The progress bar characters were hardcoded, making it impossible to customize the bar style. A common request is circle/dot-style indicators:

```toml
[cship.context_bar]
filled_char = "●"
empty_char  = "○"
```

which renders as `●●●●○○○○○○40%` instead of `████░░░░░░40%`.

## Changes

- `src/config.rs`: added `filled_char: Option<String>` and `empty_char: Option<String>` to `ContextBarConfig`
- `src/modules/context_bar.rs`: read the new fields with fallback to defaults; updated doc comment
- Added two new unit tests covering custom chars and partial override

## Test plan

- [x] All 66 existing tests pass (`cargo test`)
- [x] New test `test_context_bar_custom_filled_and_empty_chars` verifies circle rendering
- [x] New test `test_context_bar_only_filled_char_overridden` verifies partial override falls back to default empty char

🤖 Generated with [Claude Code](https://claude.com/claude-code)