### PR TITLE
chore(release): bump version to v1.4.2 Fixes #154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.4.2] - 2026-04-19
+
+### Added
+- Added `cship.peak_usage` module — shows a configurable peak-time indicator during Anthropic's high-load hours (Mon–Fri 07:00–17:00 US Pacific by default), with zero new dependencies ([@timoklein](https://github.com/timoklein))
+
+### Fixed
+- Fixed upgrade via re-running the install script — now runs `cship uninstall` first to remove stale binaries from all locations (e.g. `~/.cargo/bin`) before installing the latest release
+- Fixed clippy warnings in `explain.rs` and `cli.rs` tests ([@nh13](https://github.com/nh13))
+
 ## [1.4.1] - 2026-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cship"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "cship"
-version       = "1.4.1"
+version       = "1.4.2"
 edition       = "2024"
 description   = "Beautiful, Blazing-fast, Customizable Claude Code Statusline"
 license       = "Apache-2.0"

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,13 @@ esac
 
 echo "Detected: $OS/$ARCH → target: $TARGET"
 
-# ── 2. Download Binary ────────────────────────────────────────────────────────
+# ── 2. Uninstall any existing cship ───────────────────────────────────────────
+if command -v cship >/dev/null 2>&1; then
+  echo "Existing cship found — running uninstall to clean up before upgrade..."
+  cship uninstall
+fi
+
+# ── 3. Download Binary ────────────────────────────────────────────────────────
 BINARY_URL="https://github.com/stephenleo/cship/releases/latest/download/cship-${TARGET}"
 mkdir -p "$INSTALL_DIR"
 echo "Downloading cship from $BINARY_URL ..."
@@ -43,7 +49,7 @@ if [ ! -s "${INSTALL_DIR}/cship" ]; then
 fi
 echo "Installed cship to ${INSTALL_DIR}/cship"
 
-# ── 3. Linux: libsecret-tools check (usage limits dependency) ─────────────────
+# ── 4. Linux: libsecret-tools check (usage limits dependency) ─────────────────
 if [ "$OS" = "Linux" ] && ! command -v secret-tool >/dev/null 2>&1; then
   printf "Install libsecret-tools? (required for usage limits on Linux) [Y/n] "
   read -r answer </dev/tty
@@ -53,7 +59,7 @@ if [ "$OS" = "Linux" ] && ! command -v secret-tool >/dev/null 2>&1; then
   esac
 fi
 
-# ── 4. Starship detection and optional install ────────────────────────────────
+# ── 5. Starship detection and optional install ────────────────────────────────
 if ! command -v starship >/dev/null 2>&1; then
   printf "Starship not found. Install Starship? (required for passthrough modules) [Y/n] "
   read -r answer </dev/tty
@@ -63,7 +69,7 @@ if ! command -v starship >/dev/null 2>&1; then
   esac
 fi
 
-# ── 5. cship.toml — create minimal config (idempotent) ───────────────────────
+# ── 6. cship.toml — create minimal config (idempotent) ───────────────────────
 CSHIP_CONFIG="$ROOT/.config/cship.toml"
 mkdir -p "$(dirname "$CSHIP_CONFIG")"
 
@@ -112,7 +118,7 @@ else
   echo "Created minimal cship config at $CSHIP_CONFIG"
 fi
 
-# ── 6. ~/.claude/settings.json — wire statusline (via python3) ───────────────
+# ── 7. ~/.claude/settings.json — wire statusline (via python3) ───────────────
 SETTINGS="$ROOT/.claude/settings.json"
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Warning: python3 not found. Skipping settings.json update."
@@ -140,7 +146,7 @@ else
   echo "settings.json not found at $SETTINGS — skipping (Claude Code may not be installed yet)."
 fi
 
-# ── 7. First-run preview ──────────────────────────────────────────────────────
+# ── 8. First-run preview ──────────────────────────────────────────────────────
 echo ""
 echo "Running cship explain..."
 "$INSTALL_DIR/cship" explain || true


### PR DESCRIPTION
## Summary

- Bumps version to 1.4.2 in `Cargo.toml` and `Cargo.lock`
- Updates `CHANGELOG.md` with entries for `peak_usage` module, install upgrade fix, and clippy fixes
- Fixes `install.sh` to run `cship uninstall` before downloading the new binary, resolving upgrades when the old binary lives in a different PATH location (e.g. `~/.cargo/bin` from a prior `cargo install`) — closes #154

## Test plan

- [x] `bash -n install.sh` — syntax check passes
- [x] `cargo build` — compiles clean
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)