### PR TITLE
fix(install): run cship uninstall before upgrade on Windows Fixes #154

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -32,6 +32,13 @@ if ($arch -eq "AMD64") {
     exit 1
 }
 
+# --- Uninstall any existing cship ---
+$existingCship = Get-Command cship -ErrorAction SilentlyContinue
+if ($existingCship) {
+    Write-Host "Existing cship found — running uninstall to clean up before upgrade..."
+    & $existingCship.Source uninstall
+}
+
 # --- Fetch latest release tag ---
 Write-Host "Fetching latest cship release..."
 $releaseUrl = "https://api.github.com/repos/$REPO/releases/latest"


### PR DESCRIPTION
## Summary

- `install.sh` already calls `cship uninstall` before reinstalling on Unix/macOS; `install.ps1` was missing the equivalent
- Adds a pre-install check using `Get-Command cship -ErrorAction SilentlyContinue` — if a prior installation is found, runs `cship uninstall` via the resolved binary path before downloading the new release
- Prevents stale binaries, duplicate `statusLine` entries in `settings.json`, and orphaned project caches on repeated Windows installs

## Test plan

- [ ] Run `install.ps1` on a Windows machine with an existing cship install — confirm "Existing cship found" message appears and old state is cleaned up
- [ ] Run `install.ps1` on a clean Windows machine (no prior cship) — confirm no uninstall message, install completes normally
- [ ] After reinstall, verify `~/.claude/settings.json` has exactly one `statusLine` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)