### PR TITLE
fix(install): support non-interactive environments and add --yes flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.5.0] - 2026-04-19
+
+### Fixed
+- Fixed `install.sh` failing in non-interactive environments (Docker `RUN`, CI pipelines) — the installer no longer opens `/dev/tty` when no terminal is available, instead printing skip messages for optional dependencies
+
+### Added
+- Added `--yes` / `-y` flag to `install.sh` to auto-install all optional dependencies (Starship, `libsecret-tools` on Linux) without prompting
+
 ## [1.4.2] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cship"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "cship"
-version       = "1.4.2"
+version       = "1.5.0"
 edition       = "2024"
 description   = "Beautiful, Blazing-fast, Customizable Claude Code Statusline"
 license       = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,16 @@
 curl -fsSL https://cship.dev/install.sh | bash
 ```
 
-Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64), downloads the binary to `~/.local/bin/cship`, creates a starter config at `~/.config/cship.toml`, wires the `statusLine` entry in `~/.claude/settings.json`, and optionally installs [Starship](https://starship.rs) (needed for passthrough modules) and, on Linux, `libsecret-tools` (needed for usage limits).
+Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64), downloads the binary to `~/.local/bin/cship`, creates a starter config at `~/.config/cship.toml`, and wires the `statusLine` entry in `~/.claude/settings.json`.
+
+Optional dependencies ([Starship](https://starship.rs) for passthrough modules, and `libsecret-tools` on Linux for usage limits) are handled as follows:
+
+- **Interactive terminal** — the installer prompts you for each.
+- **`--yes` / `-y`** — auto-installs all optional deps without prompting:
+  ```sh
+  curl -fsSL https://cship.dev/install.sh | bash -s -- --yes
+  ```
+- **Non-interactive** (Docker `RUN`, CI pipelines, no TTY) — optional deps are skipped automatically; the installer prints instructions for manual installation.
 
 ### 🪟 Method 1b: PowerShell installer (Windows)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,16 @@ If you've already invested in Starship customization, CShip slots right in: add 
 curl -fsSL https://cship.dev/install.sh | bash
 ```
 
-Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64), downloads the binary to `~/.local/bin/cship`, creates a starter config at `~/.config/cship.toml`, wires the `statusLine` entry in `~/.claude/settings.json`, and optionally installs [Starship](https://starship.rs) and `libsecret-tools` (Linux only, needed for usage limits).
+Auto-detects your OS and architecture (macOS arm64/x86_64, Linux x86_64/aarch64), downloads the binary to `~/.local/bin/cship`, creates a starter config at `~/.config/cship.toml`, and wires the `statusLine` entry in `~/.claude/settings.json`.
+
+Optional dependencies ([Starship](https://starship.rs) for passthrough modules, and `libsecret-tools` on Linux for usage limits) are handled as follows:
+
+- **Interactive terminal** — the installer prompts you for each.
+- **`--yes` / `-y`** — auto-installs all optional deps without prompting:
+  ```sh
+  curl -fsSL https://cship.dev/install.sh | bash -s -- --yes
+  ```
+- **Non-interactive** (Docker `RUN`, CI pipelines, no TTY) — optional deps are skipped automatically; the installer prints instructions for manual installation.
 
 ### Windows {#install-windows}
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ── 0. Argument parsing ───────────────────────────────────────────────────────
+YES=false
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) YES=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# ── 0b. Interactive detection ─────────────────────────────────────────────────
+# Non-interactive when /dev/tty is unavailable (Docker, CI pipelines, etc.)
+INTERACTIVE=false
+if { exec 3</dev/tty && exec 3<&-; } 2>/dev/null; then
+  INTERACTIVE=true
+fi
+
 # Allow CSHIP_TEST_ROOT to override HOME for all path resolution (testability)
 ROOT="${CSHIP_TEST_ROOT:-$HOME}"
 INSTALL_DIR="$ROOT/.local/bin"
@@ -51,22 +67,34 @@ echo "Installed cship to ${INSTALL_DIR}/cship"
 
 # ── 4. Linux: libsecret-tools check (usage limits dependency) ─────────────────
 if [ "$OS" = "Linux" ] && ! command -v secret-tool >/dev/null 2>&1; then
-  printf "Install libsecret-tools? (required for usage limits on Linux) [Y/n] "
-  read -r answer </dev/tty
-  case "$answer" in
-    [Nn]*) echo "Skipping — usage limits module unavailable until installed manually." ;;
-    *)     sudo apt-get install -y libsecret-tools ;;
-  esac
+  if [ "$YES" = "true" ]; then
+    sudo apt-get install -y libsecret-tools
+  elif [ "$INTERACTIVE" = "true" ]; then
+    printf "Install libsecret-tools? (required for usage limits on Linux) [Y/n] "
+    read -r answer </dev/tty
+    case "$answer" in
+      [Nn]*) echo "Skipping — usage limits module unavailable until installed manually." ;;
+      *)     sudo apt-get install -y libsecret-tools ;;
+    esac
+  else
+    echo "Skipping libsecret-tools (non-interactive). Re-run with --yes or install manually: sudo apt-get install -y libsecret-tools"
+  fi
 fi
 
 # ── 5. Starship detection and optional install ────────────────────────────────
 if ! command -v starship >/dev/null 2>&1; then
-  printf "Starship not found. Install Starship? (required for passthrough modules) [Y/n] "
-  read -r answer </dev/tty
-  case "$answer" in
-    [Nn]*) echo "Skipping Starship install. Native cship modules will still work." ;;
-    *)     curl -sS https://starship.rs/install.sh | sh ;;
-  esac
+  if [ "$YES" = "true" ]; then
+    curl -sS https://starship.rs/install.sh | sh -s -- --yes
+  elif [ "$INTERACTIVE" = "true" ]; then
+    printf "Starship not found. Install Starship? (required for passthrough modules) [Y/n] "
+    read -r answer </dev/tty
+    case "$answer" in
+      [Nn]*) echo "Skipping Starship install. Native cship modules will still work." ;;
+      *)     curl -sS https://starship.rs/install.sh | sh ;;
+    esac
+  else
+    echo "Skipping Starship install (non-interactive). Re-run with --yes or install manually: curl -sS https://starship.rs/install.sh | sh"
+  fi
 fi
 
 # ── 6. cship.toml — create minimal config (idempotent) ───────────────────────


### PR DESCRIPTION
## Summary

- Adds a TTY probe (`exec 3</dev/tty`) before both optional-dependency prompts so Docker `RUN` steps and CI pipelines no longer fail with `No such device or address` when `/dev/tty` is unavailable
- Adds `--yes` / `-y` flag to auto-install all optional deps (Starship, libsecret-tools on Linux) without prompting — useful for Dockerfiles that want a full setup
- Interactive terminal behaviour is **unchanged** — prompts still appear when a TTY is available and `--yes` is not passed
- Updates `README.md` and `docs/index.md` to document all three modes

## Behaviour matrix

| Context | libsecret-tools | Starship |
|---------|----------------|---------|
| `--yes` / `-y` | auto-install | auto-install |
| Interactive terminal (no flag) | prompt (unchanged) | prompt (unchanged) |
| Non-interactive / no TTY | skip + message | skip + message |

## Test plan

- [x] `CSHIP_TEST_ROOT=/tmp/t bash install.sh` — completes with exit 0, prints skip messages for optional deps
- [x] `CSHIP_TEST_ROOT=/tmp/t bash install.sh --yes` — auto-installs Starship (and libsecret-tools on Linux)
- [x] `CSHIP_TEST_ROOT=/tmp/t bash install.sh -y` — shorthand works identically
- [x] `bash -n install.sh` — syntax check passes
- [x] Docker reproduction from issue: `docker build` with `RUN curl -fsSL https://cship.dev/install.sh | bash` exits 0

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)