### PR TITLE
fix(session): show cship binary version in cship.version module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.5.1] - 2026-04-20
+
+### Fixed
+- Fixed `$cship.version` to display the installed cship binary version instead of the Claude Code CLI version — now uses compile-time `CARGO_PKG_VERSION`, ensuring the statusline reflects the actual installed binary version
+
+### Added
+- Added `-v` / `--version` CLI flags to print the cship binary version
+
 ## [1.5.0] - 2026-04-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cship"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "cship"
-version       = "1.5.0"
+version       = "1.5.1"
 edition       = "2024"
 description   = "Beautiful, Blazing-fast, Customizable Claude Code Statusline"
 license       = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ Run `cship explain` to inspect what cship sees from Claude Code's context JSON �
 cship explain
 ```
 
+To check the installed binary version:
+
+```sh
+cship --version   # or: cship -v
+```
+
 ## ✨ Showcase
 
 Six ready-to-use configurations — from minimal to full-featured. Each can be dropped into `~/.config/cship.toml`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,4 +152,10 @@ cship explain
 
 This shows each module's current rendered value, the config file path in use, and any warnings about missing data or misconfiguration.
 
+To check the installed binary version:
+
+```sh
+cship --version   # or: cship -v
+```
+
 ## Inspired by [Starship](https://starship.rs)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,10 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "cship", about = "Claude Code statusline renderer")]
 struct Cli {
+    /// Print cship version and exit
+    #[arg(short = 'v', long = "version")]
+    version: bool,
+
     /// Path to starship.toml config file. Bypasses automatic discovery.
     #[arg(long, global = true, value_name = "PATH")]
     config: Option<PathBuf>,
@@ -30,6 +34,11 @@ fn main() {
 
     // Parse CLI args — must happen before any fallible operations.
     let cli = Cli::parse();
+
+    if cli.version {
+        println!("cship {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
 
     match cli.command {
         Some(Commands::Explain) => {

--- a/src/modules/session.rs
+++ b/src/modules/session.rs
@@ -96,9 +96,9 @@ pub fn render_transcript_path(
     Some(crate::ansi::apply_style(&content, style))
 }
 
-/// Renders `$cship.version` — Claude Code version string from Context.
+/// Renders `$cship.version` — cship binary version (compile-time CARGO_PKG_VERSION).
 pub fn render_version(
-    ctx: &crate::context::Context,
+    _ctx: &crate::context::Context,
     cfg: &crate::config::CshipConfig,
 ) -> Option<String> {
     if cfg
@@ -109,13 +109,7 @@ pub fn render_version(
     {
         return None;
     }
-    let value = match ctx.version.as_deref() {
-        Some(v) => v,
-        None => {
-            tracing::warn!("cship.version: field absent from context");
-            return None;
-        }
-    };
+    let value = env!("CARGO_PKG_VERSION");
     let sess_cfg = cfg.session.as_ref();
     let symbol = sess_cfg.and_then(|s| s.symbol.as_deref());
     let style = sess_cfg.and_then(|s| s.style.as_deref());
@@ -273,21 +267,15 @@ mod tests {
     // ── version ───────────────────────────────────────────────────────────
 
     #[test]
-    fn test_render_version_renders_value() {
-        let ctx = Context {
-            version: Some("1.0.80".to_string()),
-            ..Default::default()
-        };
+    fn test_render_version_renders_binary_version() {
+        let ctx = Context::default();
         let result = render_version(&ctx, &CshipConfig::default());
-        assert_eq!(result, Some("1.0.80".to_string()));
+        assert_eq!(result, Some(env!("CARGO_PKG_VERSION").to_string()));
     }
 
     #[test]
     fn test_render_version_disabled_returns_none() {
-        let ctx = Context {
-            version: Some("1.0.80".to_string()),
-            ..Default::default()
-        };
+        let ctx = Context::default();
         let cfg = CshipConfig {
             session: Some(SessionConfig {
                 disabled: Some(true),
@@ -296,12 +284,6 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(render_version(&ctx, &cfg), None);
-    }
-
-    #[test]
-    fn test_render_version_absent_returns_none() {
-        let ctx = Context::default();
-        assert_eq!(render_version(&ctx, &CshipConfig::default()), None);
     }
 
     // ── output_style ──────────────────────────────────────────────────────

--- a/src/sample_context.json
+++ b/src/sample_context.json
@@ -2,7 +2,7 @@
   "cwd": "/home/user/projects/myproject",
   "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "transcript_path": "/home/user/.claude/projects/myproject/transcript.jsonl",
-  "version": "1.0.80",
+  "version": "2.0.31",
   "exceeds_200k_tokens": false,
   "model": {
     "id": "claude-sonnet-4-6",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -31,6 +31,24 @@ fn test_empty_stdin_exits_nonzero_with_no_stdout() {
 }
 
 #[test]
+fn test_version_flag_short_prints_version() {
+    cship()
+        .arg("-v")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn test_version_flag_long_prints_version() {
+    cship()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
 fn test_malformed_json_exits_nonzero_with_no_stdout() {
     cargo_bin_cmd!("cship")
         .write_stdin("not valid json{{{")
@@ -609,13 +627,12 @@ fn test_session_transcript_path_renders_string() {
 #[test]
 fn test_session_version_renders_string() {
     let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
-    // sample_input_full.json: version = "1.0.80"
     cship()
         .args(["--config", "tests/fixtures/session_version.toml"])
         .write_stdin(json)
         .assert()
         .success()
-        .stdout(predicate::str::contains("1.0.80"));
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `$cship.version` previously displayed the Claude Code CLI version from the JSON context payload (`ctx.version`), which meant upgrading cship had no visible effect on the displayed value
- It now uses `env!("CARGO_PKG_VERSION")` at compile time so it always reflects the installed cship binary version
- Adds `-v`/`--version` CLI flags (`cship -v` / `cship --version`)
- Updates `sample_context.json` from stale `1.0.80` → `2.0.31`

Closes #154

## Test plan

- [ ] `cargo test` — all 413 tests pass
- [ ] `cship -v` prints `cship 1.5.0`
- [ ] `cship --version` prints `cship 1.5.0`
- [ ] `$cship.version` in statusline shows `1.5.0` (not Claude Code's version)
- [ ] `cship explain` shows `1.5.0` for `cship.version` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)