### PR TITLE
CHORE: bring Windows installer to parity with Mac/Linux    

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@
     Install cship - Claude Code statusline tool for Windows.
 .DESCRIPTION
     Downloads the cship binary from GitHub Releases, installs it to
-    %LOCALAPPDATA%\Programs\cship\, writes a default cship.toml, and
+    %USERPROFILE%\.local\bin\, writes a default cship.toml, and
     registers the statusline in Claude Code's settings.json.
 .PARAMETER Yes
     Non-interactive mode: accept all prompts automatically.
@@ -83,23 +83,25 @@ if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
         Write-Host "Starship not found, and winget is not available on this system."
         Write-Host "Install Starship manually from https://starship.rs/ then re-run this script."
         Write-Host "Native cship modules will still work without Starship."
-    } elseif ($Yes) {
-        & $winget.Source install --id Starship.Starship --accept-source-agreements --accept-package-agreements
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
-        }
-    } elseif ($INTERACTIVE) {
-        $answer = Read-Host "Starship not found. Install Starship? (required for passthrough modules) [Y/n]"
-        if ($answer -match '^[Nn]') {
-            Write-Host "Skipping Starship install. Native cship modules will still work."
-        } else {
+    } else {
+        $installStarship = {
             & $winget.Source install --id Starship.Starship --accept-source-agreements --accept-package-agreements
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
             }
         }
-    } else {
-        Write-Host "Skipping Starship install (non-interactive). Re-run with -Yes or install manually from https://starship.rs/"
+        if ($Yes) {
+            & $installStarship
+        } elseif ($INTERACTIVE) {
+            $answer = Read-Host "Starship not found. Install Starship? (required for passthrough modules) [Y/n]"
+            if ($answer -match '^[Nn]') {
+                Write-Host "Skipping Starship install. Native cship modules will still work."
+            } else {
+                & $installStarship
+            }
+        } else {
+            Write-Host "Skipping Starship install (non-interactive). Re-run with -Yes or install manually from https://starship.rs/"
+        }
     }
 }
 
@@ -155,9 +157,9 @@ if (-not (Test-Path $claudeDir)) {
     Write-Host "Claude Code settings directory not found at $claudeDir - skipping settings update."
     Write-Host "Authenticate in Claude Code first, then re-run this script."
 } elseif (-not (Test-Path $SETTINGS)) {
-    # Create minimal settings.json
-    New-Item -ItemType Directory -Force -Path $claudeDir | Out-Null
-    '{"statusLine": {"type": "command", "command": "cship"}}' | Set-Content -Path $SETTINGS -Encoding UTF8
+    # Create minimal settings.json — $claudeDir already exists (checked above)
+    $utf8NoBom = [System.Text.Encoding]::UTF8
+    [System.IO.File]::WriteAllText($SETTINGS, '{"statusLine": {"type": "command", "command": "cship"}}', $utf8NoBom)
     Write-Host "Created settings.json with statusLine entry: $SETTINGS"
 } else {
     $json = Get-Content $SETTINGS -Raw | ConvertFrom-Json
@@ -167,7 +169,8 @@ if (-not (Test-Path $claudeDir)) {
     } else {
         $json.statusLine = $statusLineValue
     }
-    $json | ConvertTo-Json -Depth 100 | Set-Content -Path $SETTINGS -Encoding UTF8
+    $utf8NoBom = [System.Text.Encoding]::UTF8
+    [System.IO.File]::WriteAllText($SETTINGS, ($json | ConvertTo-Json -Depth 100), $utf8NoBom)
     Write-Host "Updated settings.json with statusLine entry: $SETTINGS"
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -76,16 +76,30 @@ if ($currentPath -notlike "*$INSTALL_DIR*") {
 }
 
 # --- Starship detection and optional install ---
+$INTERACTIVE = [Environment]::UserInteractive -and -not [Console]::IsInputRedirected
 if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
-    if ($Yes) {
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $winget) {
+        Write-Host "Starship not found, and winget is not available on this system."
+        Write-Host "Install Starship manually from https://starship.rs/ then re-run this script."
+        Write-Host "Native cship modules will still work without Starship."
+    } elseif ($Yes) {
         winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
-    } else {
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
+        }
+    } elseif ($INTERACTIVE) {
         $answer = Read-Host "Starship not found. Install Starship? (required for passthrough modules) [Y/n]"
         if ($answer -match '^[Nn]') {
             Write-Host "Skipping Starship install. Native cship modules will still work."
         } else {
             winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
+            }
         }
+    } else {
+        Write-Host "Skipping Starship install (non-interactive). Re-run with -Yes or install manually from https://starship.rs/"
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
     Install cship - Claude Code statusline tool for Windows.
@@ -6,7 +6,10 @@
     Downloads the cship binary from GitHub Releases, installs it to
     %LOCALAPPDATA%\Programs\cship\, writes a default cship.toml, and
     registers the statusline in Claude Code's settings.json.
+.PARAMETER Yes
+    Non-interactive mode: accept all prompts automatically.
 #>
+param([switch]$Yes)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
@@ -72,18 +75,60 @@ if ($currentPath -notlike "*$INSTALL_DIR*") {
     Write-Host "Added $INSTALL_DIR to your user PATH (effective in new shells)."
 }
 
+# --- Starship detection and optional install ---
+if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
+    if ($Yes) {
+        winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
+    } else {
+        $answer = Read-Host "Starship not found. Install Starship? (required for passthrough modules) [Y/n]"
+        if ($answer -match '^[Nn]') {
+            Write-Host "Skipping Starship install. Native cship modules will still work."
+        } else {
+            winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
+        }
+    }
+}
+
 # --- Write default cship.toml ---
 if (-not (Test-Path $CONFIG_FILE)) {
     New-Item -ItemType Directory -Force -Path $CONFIG_DIR | Out-Null
     @'
+# cship — Claude Code statusline
+# Full config reference: https://cship.dev
 [cship]
-lines = ["$cship.model $cship.cost"]
+lines = [
+  "$directory$git_branch$git_status$python$nodejs$rust",
+  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits"
+]
 
 [cship.model]
-disabled = false
+symbol = "🤖 "
+style  = "bold cyan"
+
+[cship.context_bar]
+width              = 10
+style              = "fg:#7dcfff"
+warn_threshold     = 40.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 70.0
+critical_style     = "bold fg:#f7768e"
 
 [cship.cost]
-disabled = false
+symbol             = "💰 "
+style              = "fg:#a9b1d6"
+warn_threshold     = 2.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 5.0
+critical_style     = "bold fg:#f7768e"
+
+[cship.usage_limits]
+five_hour_format   = "⌛ 5h {pct}% ({reset})"
+seven_day_format   = "📅 7d {pct}% ({reset})"
+separator          = " "
+warn_threshold     = 60.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 80.0
+critical_style     = "bold fg:#f7768e"
 '@ | Set-Content -Path $CONFIG_FILE -Encoding UTF8
     Write-Host "Config written to: $CONFIG_FILE"
 } else {

--- a/install.ps1
+++ b/install.ps1
@@ -108,7 +108,7 @@ if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
 # --- Write default cship.toml ---
 if (-not (Test-Path $CONFIG_FILE)) {
     New-Item -ItemType Directory -Force -Path $CONFIG_DIR | Out-Null
-    @'
+    $tomlContent = @'
 # cship — Claude Code statusline
 # Full config reference: https://cship.dev
 [cship]
@@ -145,7 +145,8 @@ warn_threshold     = 60.0
 warn_style         = "fg:#e0af68"
 critical_threshold = 80.0
 critical_style     = "bold fg:#f7768e"
-'@ | Set-Content -Path $CONFIG_FILE -Encoding UTF8
+'@
+    [System.IO.File]::WriteAllText($CONFIG_FILE, $tomlContent, (New-Object System.Text.UTF8Encoding $false))
     Write-Host "Config written to: $CONFIG_FILE"
 } else {
     Write-Host "Config already exists at $CONFIG_FILE - skipping."
@@ -158,7 +159,7 @@ if (-not (Test-Path $claudeDir)) {
     Write-Host "Authenticate in Claude Code first, then re-run this script."
 } elseif (-not (Test-Path $SETTINGS)) {
     # Create minimal settings.json — $claudeDir already exists (checked above)
-    $utf8NoBom = [System.Text.Encoding]::UTF8
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
     [System.IO.File]::WriteAllText($SETTINGS, '{"statusLine": {"type": "command", "command": "cship"}}', $utf8NoBom)
     Write-Host "Created settings.json with statusLine entry: $SETTINGS"
 } else {
@@ -169,7 +170,7 @@ if (-not (Test-Path $claudeDir)) {
     } else {
         $json.statusLine = $statusLineValue
     }
-    $utf8NoBom = [System.Text.Encoding]::UTF8
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
     [System.IO.File]::WriteAllText($SETTINGS, ($json | ConvertTo-Json -Depth 100), $utf8NoBom)
     Write-Host "Updated settings.json with statusLine entry: $SETTINGS"
 }

--- a/install.ps1
+++ b/install.ps1
@@ -84,7 +84,7 @@ if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
         Write-Host "Install Starship manually from https://starship.rs/ then re-run this script."
         Write-Host "Native cship modules will still work without Starship."
     } elseif ($Yes) {
-        winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
+        & $winget.Source install --id Starship.Starship --accept-source-agreements --accept-package-agreements
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
         }
@@ -93,7 +93,7 @@ if (-not (Get-Command starship -ErrorAction SilentlyContinue)) {
         if ($answer -match '^[Nn]') {
             Write-Host "Skipping Starship install. Native cship modules will still work."
         } else {
-            winget install --id Starship.Starship --accept-source-agreements --accept-package-agreements
+            & $winget.Source install --id Starship.Starship --accept-source-agreements --accept-package-agreements
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Starship installation via winget failed (exit code $LASTEXITCODE). Install manually from https://starship.rs/"
             }


### PR DESCRIPTION
  ### Problem                                                                       
   
  The Windows installer (`install.ps1`) had a minimal default `cship.toml` that was 
  never updated to match the Mac/Linux installer (`install.sh`):                

  - Only showed `model` and `cost`, missing `context_bar` and `usage_limits`
  - No styling, symbols, or warn/critical thresholds
  - No Starship passthrough line (because Starship was never installed)

  ### Changes

  **Starship install via winget**

  Added Starship detection and installation using `winget`, mirroring the `curl |
  sh` step in `install.sh`. Prompts interactively by default; accepts automatically
  with `-Yes`.

  **`-Yes` switch parameter**

  Added `param([switch]$Yes)` to support non-interactive installs (CI, scripted
  environments), matching bash's `--yes`/`-y` flag.

  **Default `cship.toml` now identical across platforms**

  The written config now matches Mac/Linux exactly: both prompt lines, all four
  modules (`model`, `cost`, `context_bar`, `usage_limits`), full styling with
  symbols and warn/critical thresholds.

  ### Testing

  Ran `.\install.ps1 -Yes` end-to-end on Windows 11:
  - Uninstalled existing cship, downloaded v1.5.1 ✓
  - Starship not present → winget installed v1.25.0 ✓
  - `cship.toml` written with correct content (all modules, emoji, thresholds) ✓
  - `settings.json` updated with `statusLine` entry ✓
  - Also tested as per README.md  (Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s )
  Full test suite passed: `337 passed; 0 failed; 1 ignored`
