### PR TITLE
Add currency_symbol and conversion_rate config to cost module

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Everything in the [Claude Code status line documentation](https://code.claude.co
 |-------|-------------|
 | `$starship_prompt` | Full rendered Starship prompt (all configured modules in one row) |
 | `$cship.model` | Claude model name |
-| `$cship.cost` | Session cost in USD ($X.XX) |
+| `$cship.cost` | Session cost (configurable currency; default `$X.XX`) |
 | `$cship.context_bar` | Visual progress bar of context window usage |
 | `$cship.context_window` | Context window tokens (used/total) |
 | `$cship.context_window.used_tokens` | Real token count in context with percentage (e.g. `8%(79k/1000k)`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ style  = "bold fg:#7aa2f7"
 
 ## `[cship.cost]` — Session Cost
 
-Displays total session cost in USD. Supports threshold-based colour escalation.
+Displays total session cost with threshold-based colour escalation. The display currency and conversion rate are configurable; the underlying value is always `total_cost_usd` (USD). Thresholds are always evaluated against the raw USD value.
 
 **Token:** `$cship.cost`
 
@@ -110,8 +110,10 @@ Displays total session cost in USD. Supports threshold-based colour escalation.
 | `warn_style` | `string` | `"yellow"` | Style applied when cost ≥ `warn_threshold` |
 | `critical_threshold` | `float` | — | USD amount at which style switches to `critical_style` |
 | `critical_style` | `string` | `"bold red"` | Style applied when cost ≥ `critical_threshold` |
+| `currency_symbol` | `string` | `"$"` | Symbol prepended to the displayed value (e.g. `"£"`, `"€"`) |
+| `conversion_rate` | `float` | `1.0` | Multiplier applied to `total_cost_usd` before display; thresholds are still evaluated in USD |
 
-**Variables:** `$value` (e.g. `$1.23`), `$symbol`, `$style`
+**Variables:** `$value` (e.g. `$1.23` or `£0.97` with a custom currency), `$symbol`, `$style`
 
 ```toml
 [cship.cost]

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,13 @@ pub struct CostConfig {
     pub critical_threshold: Option<f64>,
     pub critical_style: Option<String>,
     pub format: Option<String>,
+    /// Currency symbol to display instead of `$`. Defaults to `$`.
+    /// Example: `"£"` or `"€"`.
+    pub currency_symbol: Option<String>,
+    /// Multiplier applied to `total_cost_usd` before display. Defaults to `1.0` (no conversion).
+    /// Note: `warn_threshold` and `critical_threshold` are always compared against the raw
+    /// USD value — configure them in USD regardless of the conversion rate.
+    pub conversion_rate: Option<f64>,
     // Sub-field per-display configs (map to [cship.cost.total_cost_usd] etc.)
     pub total_cost_usd: Option<SubfieldConfig>,
     pub total_duration_ms: Option<SubfieldConfig>,

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -2,16 +2,23 @@
 use crate::config::CostSubfieldConfig;
 /// Render the `[cship.cost]` family of modules.
 ///
-/// `$cship.cost` — convenience alias: formats total_cost_usd as "$X.XX" with threshold styling.
+/// `$cship.cost` — convenience alias: formats total_cost_usd with threshold styling.
+/// Display currency and conversion rate are configurable via `currency_symbol` and
+/// `conversion_rate`; the underlying context value is always `total_cost_usd` (USD).
+/// Threshold styling (`warn_threshold`, `critical_threshold`) is always evaluated
+/// against the raw USD value, regardless of any conversion rate applied for display.
 /// `$cship.cost.total_cost_usd` — raw USD value, 4 decimal places.
-/// `$cship.cost.total_duration_ms` / `total_api_duration_ms` — integer milliseconds.
-/// `$cship.cost.total_lines_added` / `total_lines_removed` — integer counts.
+/// `$cship.cost.total_duration_ms` / `$cship.cost.total_api_duration_ms` — integer milliseconds.
+/// `$cship.cost.total_lines_added` / `$cship.cost.total_lines_removed` — integer counts.
 ///
 /// [Source: epics.md#Story 2.1, architecture.md#Structure Patterns]
 use crate::config::{CostConfig, CshipConfig};
 use crate::context::Context;
 
-/// Renders `$cship.cost` — total cost as `$X.XX` with threshold color escalation.
+/// Renders `$cship.cost` — total cost with threshold color escalation.
+/// Display format is `{currency_symbol}{value:.2}` (default: `$X.XX`).
+/// `currency_symbol` and `conversion_rate` are configurable; thresholds are always
+/// evaluated against the raw USD value from context.
 pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let cost_cfg = cfg.cost.as_ref();
 
@@ -31,7 +38,12 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
 
     let symbol = cost_cfg.and_then(|c| c.symbol.as_deref());
     let style = cost_cfg.and_then(|c| c.style.as_deref());
-    let formatted = format!("${:.2}", val);
+    let currency_symbol = cost_cfg
+        .and_then(|c| c.currency_symbol.as_deref())
+        .unwrap_or("$");
+    let conversion_rate = cost_cfg.and_then(|c| c.conversion_rate).unwrap_or(1.0);
+    let converted_val = val * conversion_rate;
+    let formatted = format!("{}{:.2}", currency_symbol, converted_val);
 
     // Extract threshold variables FIRST (before format check)
     let warn_threshold = cost_cfg.and_then(|c| c.warn_threshold);
@@ -193,6 +205,56 @@ mod tests {
         let ctx = ctx_with_cost(0.01234);
         let result = render(&ctx, &CshipConfig::default());
         assert_eq!(result, Some("$0.01".to_string()));
+    }
+
+    #[test]
+    fn test_cost_renders_custom_currency_symbol() {
+        let ctx = ctx_with_cost(1.50);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                currency_symbol: Some("£".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg);
+        assert_eq!(result, Some("£1.50".to_string()));
+    }
+
+    #[test]
+    fn test_cost_renders_with_conversion_rate() {
+        let ctx = ctx_with_cost(1.00);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                currency_symbol: Some("£".to_string()),
+                conversion_rate: Some(0.79),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg);
+        assert_eq!(result, Some("£0.79".to_string()));
+    }
+
+    #[test]
+    fn test_cost_format_path_uses_converted_value() {
+        // Regression: conversion_rate and currency_symbol must flow into $value
+        // when a format string is configured (apply_module_format branch).
+        let ctx = ctx_with_cost(1.00);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                currency_symbol: Some("€".to_string()),
+                conversion_rate: Some(0.92),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains("€0.92"),
+            "expected converted value in format path: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Allows users to configure a custom currency symbol (e.g. £ instead of $) and an optional conversion rate from USD to their local currency.

Config example:
  [cship.cost]
  currency_symbol = "£"
  conversion_rate = 0.74

Updated documentation and tests to reflect changes.

This is a fix of [PR-111](https://github.com/stephenleo/cship/pull/111)
After accepting merge please close the other one.