### PR TITLE
fix(cost): evaluate thresholds against converted display value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 PRD/
 _bmad*
 .claude/
+.codex/
 .agents/
 .vscode/
 /target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+- `cship.cost` thresholds (`warn_threshold`, `critical_threshold`) are now evaluated against the converted display value (`total_cost_usd × conversion_rate`) instead of raw USD, so they live in the same currency as the displayed amount. Users with both thresholds and a non-`1.0` `conversion_rate` should restate their thresholds in the display currency
+
 ## [1.5.1] - 2026-04-20
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ style  = "bold fg:#7aa2f7"
 
 ## `[cship.cost]` — Session Cost
 
-Displays total session cost with threshold-based colour escalation. The display currency and conversion rate are configurable; the underlying value is always `total_cost_usd` (USD). Thresholds are always evaluated against the raw USD value.
+Displays total session cost with threshold-based colour escalation. The display currency and conversion rate are configurable; the underlying value is always `total_cost_usd` (USD). Thresholds are evaluated against the converted display value (`total_cost_usd × conversion_rate`); configure them in your display currency.
 
 **Token:** `$cship.cost`
 
@@ -106,12 +106,12 @@ Displays total session cost with threshold-based colour escalation. The display 
 | `style` | `string` | `"green"` | Base ANSI style |
 | `symbol` | `string` | `""` | Prefix symbol |
 | `format` | `string` | `"[$symbol$value]($style)"` | Format string |
-| `warn_threshold` | `float` | — | USD amount at which style switches to `warn_style` |
+| `warn_threshold` | `float` | — | Display-currency amount at which style switches to `warn_style` |
 | `warn_style` | `string` | `"yellow"` | Style applied when cost ≥ `warn_threshold` |
-| `critical_threshold` | `float` | — | USD amount at which style switches to `critical_style` |
+| `critical_threshold` | `float` | — | Display-currency amount at which style switches to `critical_style` |
 | `critical_style` | `string` | `"bold red"` | Style applied when cost ≥ `critical_threshold` |
 | `currency_symbol` | `string` | `"$"` | Symbol prepended to the displayed value (e.g. `"£"`, `"€"`) |
-| `conversion_rate` | `float` | `1.0` | Multiplier applied to `total_cost_usd` before display; thresholds are still evaluated in USD |
+| `conversion_rate` | `float` | `1.0` | Multiplier applied to `total_cost_usd` before display; thresholds are evaluated against the converted value, so express them in your display currency |
 
 **Variables:** `$value` (e.g. `$1.23` or `£0.97` with a custom currency), `$symbol`, `$style`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,9 @@ pub struct CostConfig {
     /// Example: `"£"` or `"€"`.
     pub currency_symbol: Option<String>,
     /// Multiplier applied to `total_cost_usd` before display. Defaults to `1.0` (no conversion).
-    /// Note: `warn_threshold` and `critical_threshold` are always compared against the raw
-    /// USD value — configure them in USD regardless of the conversion rate.
+    /// Note: `warn_threshold` and `critical_threshold` are compared against the converted value
+    /// (`total_cost_usd * conversion_rate`) — configure them in your display currency.
+    /// Should be positive; non-positive values are accepted but produce undefined threshold behavior.
     pub conversion_rate: Option<f64>,
     // Sub-field per-display configs (map to [cship.cost.total_cost_usd] etc.)
     pub total_cost_usd: Option<SubfieldConfig>,

--- a/src/modules/cost.rs
+++ b/src/modules/cost.rs
@@ -5,8 +5,9 @@ use crate::config::CostSubfieldConfig;
 /// `$cship.cost` — convenience alias: formats total_cost_usd with threshold styling.
 /// Display currency and conversion rate are configurable via `currency_symbol` and
 /// `conversion_rate`; the underlying context value is always `total_cost_usd` (USD).
-/// Threshold styling (`warn_threshold`, `critical_threshold`) is always evaluated
-/// against the raw USD value, regardless of any conversion rate applied for display.
+/// Threshold styling (`warn_threshold`, `critical_threshold`) is evaluated against
+/// the converted display value (`total_cost_usd * conversion_rate`); configure
+/// thresholds in your display currency.
 /// `$cship.cost.total_cost_usd` — raw USD value, 4 decimal places.
 /// `$cship.cost.total_duration_ms` / `$cship.cost.total_api_duration_ms` — integer milliseconds.
 /// `$cship.cost.total_lines_added` / `$cship.cost.total_lines_removed` — integer counts.
@@ -17,8 +18,9 @@ use crate::context::Context;
 
 /// Renders `$cship.cost` — total cost with threshold color escalation.
 /// Display format is `{currency_symbol}{value:.2}` (default: `$X.XX`).
-/// `currency_symbol` and `conversion_rate` are configurable; thresholds are always
-/// evaluated against the raw USD value from context.
+/// `currency_symbol` and `conversion_rate` are configurable; thresholds are
+/// evaluated against the converted display value, so configure them in your
+/// display currency.
 pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let cost_cfg = cfg.cost.as_ref();
 
@@ -54,7 +56,7 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     // Format string takes priority if configured (AC1)
     if let Some(fmt) = cost_cfg.and_then(|c| c.format.as_deref()) {
         let effective_style = crate::ansi::resolve_threshold_style(
-            Some(val),
+            Some(converted_val),
             style,
             warn_threshold,
             warn_style,
@@ -70,7 +72,7 @@ pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
 
     Some(crate::ansi::apply_style_with_threshold(
         &content,
-        Some(val),
+        Some(converted_val),
         style,
         warn_threshold,
         warn_style,
@@ -337,6 +339,92 @@ mod tests {
             result.contains('\x1b'),
             "expected critical ANSI codes: {result:?}"
         );
+    }
+
+    #[test]
+    fn test_cost_default_threshold_uses_converted_value() {
+        // Raw USD 1.0 is below warn_threshold 4.0, but converted = 5.0 trips the warn style.
+        let ctx = ctx_with_cost(1.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                conversion_rate: Some(5.0),
+                warn_threshold: Some(4.0),
+                warn_style: Some("yellow".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected warn ANSI from converted value: {result:?}"
+        );
+        assert!(result.contains("$5.00"));
+    }
+
+    #[test]
+    fn test_cost_default_below_converted_threshold_keeps_base_style() {
+        // Converted = 5.0, below warn_threshold 10.0 → no escalation.
+        let ctx = ctx_with_cost(1.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                conversion_rate: Some(5.0),
+                warn_threshold: Some(10.0),
+                warn_style: Some("yellow".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            !result.contains('\x1b'),
+            "should not escalate when converted value below threshold: {result:?}"
+        );
+        assert!(result.contains("$5.00"));
+    }
+
+    #[test]
+    fn test_cost_format_threshold_uses_converted_value() {
+        // Same converted-value comparison must apply on the format-string code path.
+        let ctx = ctx_with_cost(1.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                format: Some("[$value]($style)".to_string()),
+                conversion_rate: Some(5.0),
+                warn_threshold: Some(4.0),
+                warn_style: Some("yellow".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected warn ANSI in format path from converted value: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cost_default_critical_uses_converted_value() {
+        // Raw USD 3.0 is below critical_threshold 5.0; converted = 6.0 trips critical.
+        let ctx = ctx_with_cost(3.0);
+        let cfg = CshipConfig {
+            cost: Some(CostConfig {
+                conversion_rate: Some(2.0),
+                warn_threshold: Some(4.0),
+                warn_style: Some("yellow".to_string()),
+                critical_threshold: Some(5.0),
+                critical_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(
+            result.contains('\x1b'),
+            "expected critical ANSI from converted value: {result:?}"
+        );
+        assert!(result.contains("$6.00"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `warn_threshold` and `critical_threshold` for `[cship.cost]` are now compared against `total_cost_usd × conversion_rate` (the displayed value) instead of raw USD, so escalation fires in the same currency the user actually sees
- Follow-up to #165, which intentionally left thresholds in USD; this lands the consistency fix
- Doc comments, `docs/configuration.md`, and `CHANGELOG.md` updated to match

## Behavior change

Anyone with both thresholds set **and** a non-`1.0` `conversion_rate` will see different escalation. Restate thresholds in the display currency. Default `conversion_rate = 1.0` users see no change (`converted_val == val`).

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 379 passed / 0 failed
- [x] 4 new regression tests in `src/modules/cost.rs` lock in the converted-threshold behavior on both default and format-string code paths
- [x] Existing threshold tests pass unmodified (they don't set `conversion_rate`, so `converted_val == val`)
- [x] Subfield tests untouched — `$cship.cost.total_cost_usd` and the duration/lines subfields render via `SubfieldConfig` and never read `conversion_rate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)