### PR TITLE
docs: unify agent instructions into a single source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# cship — Claude Code Instructions
+# cship — AI Agent Instructions
 
 ## Environment Quirks
 - WSL2 ENOENT race: after any `cargo init` or file write, verify content with Read before proceeding
@@ -11,7 +11,7 @@
 - stdout owned by `main.rs` only; all module diagnostics via `tracing::*` macros; no `eprintln!` anywhere
 - Exception: CLI-action subcommands (e.g. `uninstall`, `explain`) may use `println!` directly — the stdout rule applies to the rendering pipeline only
 - All config structs: `#[derive(Debug, Deserialize, Default)]`, all fields `pub Option<T>`
-- Never add `deny_unknown_fields` to any struct — omitted intentionally on both `Context` and config structs so future Claude Code versions can add fields without breaking deserialization
+- Never add `deny_unknown_fields` to any struct — omitted intentionally on both `Context` and config structs so future versions can add fields without breaking deserialization
 
 ## Before Submitting a PR
 - Follow all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md) before opening or updating a pull request


### PR DESCRIPTION
## Summary

- Makes `CLAUDE.md` the single source of truth for all AI agent instructions
- Replaces `AGENTS.md` content with a one-line `@CLAUDE.md` import (supported by OpenAI Codex)
- Neutralizes two agent-specific phrases so the file reads correctly for any AI agent

## Test plan

- [ ] Verify `CLAUDE.md` loads correctly in Claude Code
- [ ] Verify `AGENTS.md` correctly resolves the `@CLAUDE.md` import in Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)