### PR TITLE
feat(model): add per-family style fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,13 +83,13 @@ Displays the active Claude model name.
 | `style` | `string` | `"bold"` | ANSI style (fallback when no per-family style matches) |
 | `symbol` | `string` | `""` | Prefix symbol |
 | `format` | `string` | `"[$symbol$value]($style)"` | Format string; `$value` = model display name |
-| `haiku_style` | `string` | — | Style applied when model id contains `"haiku"` |
-| `sonnet_style` | `string` | — | Style applied when model id contains `"sonnet"` |
-| `opus_style` | `string` | — | Style applied when model id contains `"opus"` |
+| `haiku_style` | `string` | — | Style applied when the key contains `"haiku"` (case-insensitive) |
+| `sonnet_style` | `string` | — | Style applied when the key contains `"sonnet"` (case-insensitive) |
+| `opus_style` | `string` | — | Style applied when the key contains `"opus"` (case-insensitive) |
 
-**Variables:** `$value` (display name, e.g. `claude-sonnet-4-5`), `$symbol`, `$style`
+**Variables:** `$value` (display name, e.g. `Claude Sonnet 4.5`), `$symbol`, `$style`
 
-Per-family styles are matched against the model id (e.g. `claude-opus-4-7`). If the id is absent, the display name is used as a fallback. When a family style is not set, `style` is used.
+Per-family styles are matched case-insensitively against `model.id` (e.g. `claude-opus-4-7`). If `id` is absent, `display_name` is used as the key instead — so a display name like `"My Sonnet Setup"` will trigger `sonnet_style`. When no family style matches or is set, `style` is used as the fallback.
 
 ```toml
 [cship.model]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,16 +80,26 @@ Displays the active Claude model name.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `disabled` | `bool` | `false` | Hide this module |
-| `style` | `string` | `"bold"` | ANSI style |
+| `style` | `string` | `"bold"` | ANSI style (fallback when no per-family style matches) |
 | `symbol` | `string` | `""` | Prefix symbol |
 | `format` | `string` | `"[$symbol$value]($style)"` | Format string; `$value` = model display name |
+| `haiku_style` | `string` | — | Style applied when model id contains `"haiku"` |
+| `sonnet_style` | `string` | — | Style applied when model id contains `"sonnet"` |
+| `opus_style` | `string` | — | Style applied when model id contains `"opus"` |
 
 **Variables:** `$value` (display name, e.g. `claude-sonnet-4-5`), `$symbol`, `$style`
+
+Per-family styles are matched against the model id (e.g. `claude-opus-4-7`). If the id is absent, the display name is used as a fallback. When a family style is not set, `style` is used.
 
 ```toml
 [cship.model]
 symbol = "🤖 "
 style  = "bold fg:#7aa2f7"
+
+# Per-model colors
+haiku_style  = "green"
+sonnet_style = "cyan"
+opus_style   = "magenta"
 ```
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub struct ModelConfig {
     /// When `true`, prepends the module name as a label.
     pub label: Option<bool>,
     pub format: Option<String>,
+    pub haiku_style: Option<String>,
+    pub sonnet_style: Option<String>,
+    pub opus_style: Option<String>,
 }
 
 /// Configuration for `[cship.cost]` — convenience alias for total cost display.

--- a/src/modules/model.rs
+++ b/src/modules/model.rs
@@ -11,15 +11,16 @@ fn resolve_model_style<'a>(
         .and_then(|m| m.id.as_deref().or(m.display_name.as_deref()))
         .map(|s| s.to_lowercase())
         .unwrap_or_default();
-    if key.contains("haiku") {
-        cfg.haiku_style.as_deref().or(cfg.style.as_deref())
+    let family = if key.contains("haiku") {
+        cfg.haiku_style.as_deref()
     } else if key.contains("sonnet") {
-        cfg.sonnet_style.as_deref().or(cfg.style.as_deref())
+        cfg.sonnet_style.as_deref()
     } else if key.contains("opus") {
-        cfg.opus_style.as_deref().or(cfg.style.as_deref())
+        cfg.opus_style.as_deref()
     } else {
-        cfg.style.as_deref()
-    }
+        None
+    };
+    family.or(cfg.style.as_deref())
 }
 
 /// Render the `[cship.model]` module.

--- a/src/modules/model.rs
+++ b/src/modules/model.rs
@@ -101,6 +101,7 @@ pub fn render_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ansi;
     use crate::config::{CshipConfig, ModelConfig};
     use crate::context::{Context, Model};
 
@@ -245,64 +246,66 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_haiku_style_applied() {
-        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
-        let cfg = CshipConfig {
+    fn all_family_cfg(haiku: &str, sonnet: &str, opus: &str, base: &str) -> CshipConfig {
+        CshipConfig {
             model: Some(ModelConfig {
-                haiku_style: Some("dim cyan".to_string()),
+                haiku_style: Some(haiku.to_string()),
+                sonnet_style: Some(sonnet.to_string()),
+                opus_style: Some(opus.to_string()),
+                style: Some(base.to_string()),
                 ..Default::default()
             }),
             ..Default::default()
-        };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes for haiku_style: {result:?}");
-        assert!(result.contains("Haiku"));
+        }
+    }
+
+    #[test]
+    fn test_haiku_style_applied() {
+        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Haiku", Some("dim cyan")),
+        );
     }
 
     #[test]
     fn test_sonnet_style_applied() {
         let ctx = ctx_with_id("claude-sonnet-4-6", "Sonnet");
-        let cfg = CshipConfig {
-            model: Some(ModelConfig {
-                sonnet_style: Some("bold blue".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes for sonnet_style: {result:?}");
-        assert!(result.contains("Sonnet"));
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Sonnet", Some("bold blue")),
+        );
     }
 
     #[test]
     fn test_opus_style_applied() {
         let ctx = ctx_with_id("claude-opus-4-7", "Opus");
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Opus", Some("bold magenta")),
+        );
+    }
+
+    #[test]
+    fn test_family_style_falls_back_to_base_style() {
+        // haiku_style not set — should use base style, not any other family style
+        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
         let cfg = CshipConfig {
             model: Some(ModelConfig {
+                style: Some("bold green".to_string()),
+                sonnet_style: Some("bold blue".to_string()),
                 opus_style: Some("bold magenta".to_string()),
                 ..Default::default()
             }),
             ..Default::default()
         };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes for opus_style: {result:?}");
-        assert!(result.contains("Opus"));
-    }
-
-    #[test]
-    fn test_family_style_falls_back_to_base_style() {
-        // haiku_style not set — should use base style
-        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
-        let cfg = CshipConfig {
-            model: Some(ModelConfig {
-                style: Some("bold green".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes from base style: {result:?}");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Haiku", Some("bold green")),
+        );
     }
 
     #[test]
@@ -314,17 +317,11 @@ mod tests {
             }),
             ..Default::default()
         };
-        let cfg = CshipConfig {
-            model: Some(ModelConfig {
-                style: Some("bold".to_string()),
-                opus_style: Some("bold magenta".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'));
-        assert!(result.contains("Future"));
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Future", Some("bold red")),
+        );
     }
 
     #[test]
@@ -336,30 +333,20 @@ mod tests {
             }),
             ..Default::default()
         };
-        let cfg = CshipConfig {
-            model: Some(ModelConfig {
-                opus_style: Some("bold magenta".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let result = render(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes via display_name fallback: {result:?}");
-        assert!(result.contains("Opus"));
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Opus", Some("bold magenta")),
+        );
     }
 
     #[test]
     fn test_render_id_honors_per_model_style() {
         let ctx = ctx_with_id("claude-opus-4-7", "Opus");
-        let cfg = CshipConfig {
-            model: Some(ModelConfig {
-                opus_style: Some("bold magenta".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let result = render_id(&ctx, &cfg).unwrap();
-        assert!(result.contains('\x1b'), "expected ANSI codes in render_id: {result:?}");
-        assert!(result.contains("claude-opus-4-7"));
+        let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render_id(&ctx, &cfg).unwrap(),
+            ansi::apply_style("claude-opus-4-7", Some("bold magenta")),
+        );
     }
 }

--- a/src/modules/model.rs
+++ b/src/modules/model.rs
@@ -1,3 +1,27 @@
+/// Resolve the effective style for the current model, preferring per-family styles over the
+/// base `style`. Family is detected from `model.id` (fallback: `display_name`) via substring.
+fn resolve_model_style<'a>(
+    ctx: &'a crate::context::Context,
+    model_cfg: Option<&'a crate::config::ModelConfig>,
+) -> Option<&'a str> {
+    let cfg = model_cfg?;
+    let key = ctx
+        .model
+        .as_ref()
+        .and_then(|m| m.id.as_deref().or(m.display_name.as_deref()))
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+    if key.contains("haiku") {
+        cfg.haiku_style.as_deref().or(cfg.style.as_deref())
+    } else if key.contains("sonnet") {
+        cfg.sonnet_style.as_deref().or(cfg.style.as_deref())
+    } else if key.contains("opus") {
+        cfg.opus_style.as_deref().or(cfg.style.as_deref())
+    } else {
+        cfg.style.as_deref()
+    }
+}
+
 /// Render the `[cship.model]` module.
 ///
 /// Output format: `{symbol}{display_name}` with optional ANSI style applied.
@@ -22,7 +46,7 @@ pub fn render(ctx: &crate::context::Context, cfg: &crate::config::CshipConfig) -
     };
 
     let symbol = model_cfg.and_then(|m| m.symbol.as_deref());
-    let style = model_cfg.and_then(|m| m.style.as_deref());
+    let style = resolve_model_style(ctx, model_cfg);
 
     // Format string takes priority if configured (AC1–4)
     if let Some(fmt) = model_cfg.and_then(|m| m.format.as_deref()) {
@@ -60,7 +84,7 @@ pub fn render_id(
         }
     };
     let symbol = model_cfg.and_then(|m| m.symbol.as_deref());
-    let style = model_cfg.and_then(|m| m.style.as_deref());
+    let style = resolve_model_style(ctx, model_cfg);
 
     // Format string takes priority if configured (AC1–4)
     if let Some(fmt) = model_cfg.and_then(|m| m.format.as_deref()) {
@@ -208,5 +232,133 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(render_id(&ctx, &cfg), None);
+    }
+
+    fn ctx_with_id(id: &str, display_name: &str) -> Context {
+        Context {
+            model: Some(Model {
+                id: Some(id.to_string()),
+                display_name: Some(display_name.to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_haiku_style_applied() {
+        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                haiku_style: Some("dim cyan".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes for haiku_style: {result:?}");
+        assert!(result.contains("Haiku"));
+    }
+
+    #[test]
+    fn test_sonnet_style_applied() {
+        let ctx = ctx_with_id("claude-sonnet-4-6", "Sonnet");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                sonnet_style: Some("bold blue".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes for sonnet_style: {result:?}");
+        assert!(result.contains("Sonnet"));
+    }
+
+    #[test]
+    fn test_opus_style_applied() {
+        let ctx = ctx_with_id("claude-opus-4-7", "Opus");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                opus_style: Some("bold magenta".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes for opus_style: {result:?}");
+        assert!(result.contains("Opus"));
+    }
+
+    #[test]
+    fn test_family_style_falls_back_to_base_style() {
+        // haiku_style not set — should use base style
+        let ctx = ctx_with_id("claude-haiku-4-5", "Haiku");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                style: Some("bold green".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes from base style: {result:?}");
+    }
+
+    #[test]
+    fn test_unknown_model_id_uses_base_style() {
+        let ctx = Context {
+            model: Some(Model {
+                id: Some("claude-future-99".to_string()),
+                display_name: Some("Future".to_string()),
+            }),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                style: Some("bold".to_string()),
+                opus_style: Some("bold magenta".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'));
+        assert!(result.contains("Future"));
+    }
+
+    #[test]
+    fn test_family_match_via_display_name_when_id_absent() {
+        let ctx = Context {
+            model: Some(Model {
+                id: None,
+                display_name: Some("Opus".to_string()),
+            }),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                opus_style: Some("bold magenta".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes via display_name fallback: {result:?}");
+        assert!(result.contains("Opus"));
+    }
+
+    #[test]
+    fn test_render_id_honors_per_model_style() {
+        let ctx = ctx_with_id("claude-opus-4-7", "Opus");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                opus_style: Some("bold magenta".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render_id(&ctx, &cfg).unwrap();
+        assert!(result.contains('\x1b'), "expected ANSI codes in render_id: {result:?}");
+        assert!(result.contains("claude-opus-4-7"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `haiku_style`, `sonnet_style`, and `opus_style` fields to `[cship.model]` so each Claude model family can have a distinct ANSI color. Matching is case-insensitive substring on `model.id`, falling back to `display_name` if `id` is absent, then to the base `style` if no family style is set.

## Changes

- New config fields in `ModelConfig`, documented in `configuration.md`
- `resolve_model_style` helper encapsulates the family detection logic
- Tests assert exact rendered output per family (not just ANSI presence), including `render_id` parity and the `display_name` fallback path

## Known limitation

Family detection is a hardcoded three-way check. A future model family that doesn't fit haiku/sonnet/opus would require a code change and a new config field. A map-based config is the natural next step but was deliberately left out of scope here.

Fixes https://github.com/stephenleo/cship/issues/166.
