### PR TITLE
feat(model): enterprise usage limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `cship.usage_limits` now renders the `extra_usage` line on Claude
+  Enterprise plans, where the OAuth API returns `five_hour` / `seven_day`
+  as `null`. Threshold styling falls back to extra-usage utilization.
+- `cship explain` now distinguishes "Enterprise plan with no extra credits
+  enabled" from "OAuth fetch failed", with a more accurate hint message.
+
+### Fixed
+- `format_extra_usage` no longer divides `used_credits` and `monthly_limit`
+  by 100. The Anthropic OAuth usage API returns whole-dollar values; the
+  divisor caused outputs to be 100× too small. Users with custom
+  `extra_usage_format` strings see corrected magnitudes.
+- `parse_api_response` no longer rejects responses where `five_hour` or
+  `seven_day` are `null` (Enterprise shape). The previous deserializer
+  required both to be objects, causing the entire fetch to fail.
+
 ## [1.6.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added
-- `cship.usage_limits` now renders the `extra_usage` line on Claude
-  Enterprise plans, where the OAuth API returns `five_hour` / `seven_day`
-  as `null`. Threshold styling falls back to extra-usage utilization.
-- `cship explain` now distinguishes "Enterprise plan with no extra credits
-  enabled" from "OAuth fetch failed", with a more accurate hint message.
-
-### Fixed
-- `parse_api_response` no longer rejects responses where `five_hour` or
-  `seven_day` are `null` (Enterprise shape). The previous deserializer
-  required both to be objects, causing the entire fetch to fail.
-
 ## [1.6.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   enabled" from "OAuth fetch failed", with a more accurate hint message.
 
 ### Fixed
-- `format_extra_usage` no longer divides `used_credits` and `monthly_limit`
-  by 100. The Anthropic OAuth usage API returns whole-dollar values; the
-  divisor caused outputs to be 100× too small. Users with custom
-  `extra_usage_format` strings see corrected magnitudes.
 - `parse_api_response` no longer rejects responses where `five_hour` or
   `seven_day` are `null` (Enterprise shape). The previous deserializer
   required both to be objects, causing the entire fetch to fail.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -422,27 +422,12 @@ Setting both formats to `""` effectively hides the combined token. Per-model sec
 
 ### Claude Enterprise plans
 
-On Claude Enterprise, the OAuth usage API returns `five_hour`, `seven_day`,
-and the per-model `seven_day_*` fields as `null` and reports usage exclusively
-through `extra_usage`. cship adapts automatically:
+On Enterprise, the OAuth usage API only populates `extra_usage` (the standard
+5h/7d fields are `null`). `cship.usage_limits` automatically renders just the
+`extra_usage` line, and threshold styling falls back to `extra_usage_utilization`.
 
-- `cship.usage_limits` renders only the formatted `extra_usage` line — no
-  `5h:` or `7d:` segments.
-- Threshold styling (`warn_threshold` / `critical_threshold`) is applied to
-  `extra_usage_utilization` instead of the (always zero) standard fields.
-- The `{active}` placeholder in `extra_usage_format` shows ⚡ once
-  utilization crosses `warn_threshold`, or for any non-zero utilization when
-  no threshold is configured.
-
-The `extra_usage_format` placeholders behave identically on Pro/Max and
-Enterprise: `{pct}`, `{used}`, `{limit}`, `{remaining_credits}`, `{active}`.
-The API reports `used_credits` and `monthly_limit` in cents, and cship divides
-by 100 for display (e.g. `monthly_limit: 30000` renders as `$300.00`). Dollar
-amounts always show two decimal places.
-
-Run `cship explain` if `cship.usage_limits` is empty on an Enterprise plan —
-it will tell you whether the credential is missing, the API call failed, or
-the plan reports no extra-credit billing.
+If `cship.usage_limits` is empty on Enterprise, run `cship explain` for
+specific diagnostics.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -436,7 +436,9 @@ through `extra_usage`. cship adapts automatically:
 
 The `extra_usage_format` placeholders behave identically on Pro/Max and
 Enterprise: `{pct}`, `{used}`, `{limit}`, `{remaining_credits}`, `{active}`.
-Values are in whole USD (the API returns dollars, not cents).
+The API reports `used_credits` and `monthly_limit` in cents, and cship divides
+by 100 for display (e.g. `monthly_limit: 30000` renders as `$300.00`). Dollar
+amounts always show two decimal places.
 
 Run `cship explain` if `cship.usage_limits` is empty on an Enterprise plan —
 it will tell you whether the credential is missing, the API call failed, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -420,6 +420,28 @@ separator        = ""
 
 Setting both formats to `""` effectively hides the combined token. Per-model sections render only when the API returns data for that model, so they disappear automatically on accounts that don't expose a given breakdown.
 
+### Claude Enterprise plans
+
+On Claude Enterprise, the OAuth usage API returns `five_hour`, `seven_day`,
+and the per-model `seven_day_*` fields as `null` and reports usage exclusively
+through `extra_usage`. cship adapts automatically:
+
+- `cship.usage_limits` renders only the formatted `extra_usage` line — no
+  `5h:` or `7d:` segments.
+- Threshold styling (`warn_threshold` / `critical_threshold`) is applied to
+  `extra_usage_utilization` instead of the (always zero) standard fields.
+- The `{active}` placeholder in `extra_usage_format` shows ⚡ once
+  utilization crosses `warn_threshold`, or for any non-zero utilization when
+  no threshold is configured.
+
+The `extra_usage_format` placeholders behave identically on Pro/Max and
+Enterprise: `{pct}`, `{used}`, `{limit}`, `{remaining_credits}`, `{active}`.
+Values are in whole USD (the API returns dollars, not cents).
+
+Run `cship explain` if `cship.usage_limits` is empty on an Enterprise plan —
+it will tell you whether the credential is missing, the API call failed, or
+the plan reports no extra-credit billing.
+
 ---
 
 ## `[cship.peak_usage]` — Peak-Time Indicator

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,6 +81,19 @@ extra_usage_format = "{active} ${used}/${limit}"
 
 ---
 
+## I'm on a Claude Enterprise plan and `cship.usage_limits` shows nothing — why?
+
+Claude Enterprise reports usage through `extra_usage` (monthly credit pool)
+rather than the standard 5-hour and 7-day windows used for Pro and Max.
+cship now renders the `extra_usage` line directly when standard fields are
+absent, with threshold styling applied to monthly credit utilization.
+
+If you still see no output, run `cship explain` — it will surface the
+specific reason (missing credential, expired token, or extra-credit billing
+not enabled on your Enterprise account).
+
+---
+
 ## How does the peak-time indicator handle time zones and DST?
 
 The `peak_usage` module checks whether the current time falls within the configured peak window in **US Pacific time**. It computes the UTC→Pacific offset internally — PDT (UTC−7) from the second Sunday of March through the first Sunday of November, PST (UTC−8) the rest of the year.

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,7 +290,7 @@ pub struct UsageLimitsConfig {
     /// Format string for extra usage display. Shown when extra_usage.is_enabled is true.
     /// Placeholders: {active}, {pct}, {used}, {limit}, {remaining_credits}
     /// `{pct}` is the integer percentage of extra-usage budget consumed; `{used}`,
-    /// `{limit}`, and `{remaining_credits}` are dollar amounts (the API reports cents).
+    /// `{limit}`, and `{remaining_credits}` are whole-dollar amounts.
     /// `{remaining_credits}` is named distinctly from the percentage-based `{remaining}`
     /// used in other format strings to avoid silent misinterpretation.
     /// Default: "{active} extra: {pct}% (${used}/${limit})"

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,7 +290,8 @@ pub struct UsageLimitsConfig {
     /// Format string for extra usage display. Shown when extra_usage.is_enabled is true.
     /// Placeholders: {active}, {pct}, {used}, {limit}, {remaining_credits}
     /// `{pct}` is the integer percentage of extra-usage budget consumed; `{used}`,
-    /// `{limit}`, and `{remaining_credits}` are whole-dollar amounts.
+    /// `{limit}`, and `{remaining_credits}` render as dollar amounts with two
+    /// decimal places (the API reports cents; cship divides by 100 for display).
     /// `{remaining_credits}` is named distinctly from the percentage-based `{remaining}`
     /// used in other format strings to avoid silent misinterpretation.
     /// Default: "{active} extra: {pct}% (${used}/${limit})"

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -241,15 +241,36 @@ fn error_hint_for(
                     "Authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
                 ),
                 Ok(_) => {
-                    // Distinguish "Enterprise plan with no extra credits enabled" from
-                    // "fetch failed". If the cache holds a successful but empty payload,
-                    // it's the former.
+                    // Distinguish three Enterprise-vs-Pro/Max cases from "fetch failed":
+                    //   1. Enterprise per-model sub-token (.opus / .sonnet / .cowork /
+                    //      .oauth_apps / .per_model) — these are inherently absent on
+                    //      Enterprise plans, which only expose monthly credits.
+                    //   2. Enterprise main token with extra_usage disabled — plan has
+                    //      neither usage windows nor extra credits.
+                    //   3. Anything else — fall back to the legacy "fetch failed" hint.
                     let cached = ctx
                         .transcript_path
                         .as_deref()
                         .map(std::path::Path::new)
                         .and_then(|p| crate::cache::read_usage_limits(p, true));
+                    let is_per_model_subtoken = matches!(
+                        top,
+                        "usage_limits.per_model"
+                            | "usage_limits.opus"
+                            | "usage_limits.sonnet"
+                            | "usage_limits.cowork"
+                            | "usage_limits.oauth_apps"
+                    );
                     match cached {
+                        Some(d)
+                            if crate::modules::usage_limits::lacks_standard_signal(&d)
+                                && is_per_model_subtoken =>
+                        {
+                            (
+                                "per-model breakdowns are unavailable on this plan".into(),
+                                "Claude Enterprise reports usage via monthly credits (`extra_usage`) only. Use `$cship.usage_limits` or `$cship.usage_limits.extra_usage` instead.".into(),
+                            )
+                        }
                         Some(d)
                             if crate::modules::usage_limits::lacks_standard_signal(&d)
                                 && d.extra_usage_enabled != Some(true) =>
@@ -603,5 +624,65 @@ mod tests {
             hint.contains("Claude Enterprise"),
             "unexpected hint: {hint}"
         );
+    }
+
+    #[test]
+    fn test_enterprise_per_model_subtoken_hint() {
+        // On Enterprise plans the per-model sub-tokens are inherently absent —
+        // they should produce a dedicated hint, not the misleading "fetch
+        // failed" message.
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript_path = tmp.path().join("transcript.jsonl");
+        std::fs::write(&transcript_path, "").unwrap();
+
+        let enterprise = crate::usage_limits::UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(7000.0),
+            extra_usage_utilization: Some(35.0),
+            ..Default::default()
+        };
+        crate::cache::write_usage_limits(&transcript_path, &enterprise, 600);
+
+        let ctx = crate::context::Context {
+            transcript_path: Some(transcript_path.to_string_lossy().into()),
+            ..Default::default()
+        };
+        let cfg = crate::config::CshipConfig::default();
+
+        // OAuth probes via macOS `security` / Linux `secret-tool` subprocesses
+        // are flaky under parallel test execution — each iteration probes
+        // independently and only asserts on iterations that landed in the
+        // `Ok(_)` branch of `error_hint_for`.
+        let mut asserted_at_least_once = false;
+        for token in [
+            "cship.usage_limits.per_model",
+            "cship.usage_limits.opus",
+            "cship.usage_limits.sonnet",
+            "cship.usage_limits.cowork",
+            "cship.usage_limits.oauth_apps",
+        ] {
+            if crate::platform::get_oauth_token().is_err() {
+                continue;
+            }
+            let (msg, hint) = error_hint_for(token, &ctx, &cfg);
+            // Tolerate iterations where OAuth flipped to Err between the probe
+            // above and the inner probe inside error_hint_for.
+            if msg.contains("credential") {
+                continue;
+            }
+            assert!(
+                msg.contains("per-model breakdowns are unavailable"),
+                "{token}: unexpected msg: {msg}"
+            );
+            assert!(
+                hint.contains("monthly credits"),
+                "{token}: unexpected hint: {hint}"
+            );
+            asserted_at_least_once = true;
+        }
+        // If every iteration's OAuth probe was unreliable, the test is
+        // a no-op — same trade-off as the sibling test above.
+        let _ = asserted_at_least_once;
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -188,7 +188,7 @@ fn is_disabled(name: &str, cfg: &crate::config::CshipConfig) -> bool {
 
 fn error_hint_for(
     name: &str,
-    _ctx: &crate::context::Context,
+    ctx: &crate::context::Context,
     cfg: &crate::config::CshipConfig,
 ) -> (String, String) {
     let top = name.strip_prefix("cship.").unwrap_or(name);
@@ -240,10 +240,31 @@ fn error_hint_for(
                     "usage_limits returned no data — no Claude Code credential found".into(),
                     "Authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
                 ),
-                Ok(_) => (
-                    "usage_limits returned no data — credential present but API fetch failed".into(),
-                    "Your Claude Code token may have expired. Re-authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
-                ),
+                Ok(_) => {
+                    // Distinguish "Enterprise plan with no extra credits enabled" from
+                    // "fetch failed". If the cache holds a successful but empty payload,
+                    // it's the former.
+                    let cached = ctx
+                        .transcript_path
+                        .as_deref()
+                        .map(std::path::Path::new)
+                        .and_then(|p| crate::cache::read_usage_limits(p, true));
+                    match cached {
+                        Some(d)
+                            if crate::modules::usage_limits::lacks_standard_signal(&d)
+                                && d.extra_usage_enabled != Some(true) =>
+                        {
+                            (
+                                "usage_limits returned no data — your plan reports no usage windows or extra credits".into(),
+                                "If you're on Claude Enterprise, ask your admin to verify extra-credit billing is enabled for your account.".into(),
+                            )
+                        }
+                        _ => (
+                            "usage_limits returned no data — credential present but API fetch failed".into(),
+                            "Your Claude Code token may have expired. Re-authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
+                        ),
+                    }
+                }
                 Err(_) => (
                     "usage_limits returned no data — credential appears malformed or tool unavailable".into(),
                     "Re-authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
@@ -544,6 +565,43 @@ mod tests {
         assert!(
             remediation.contains("login flow"),
             "remediation must include login flow instruction, got: {remediation}"
+        );
+    }
+
+    #[test]
+    fn test_enterprise_no_extra_credits_hint() {
+        // Cache holds a successfully-fetched payload with no signal at all.
+        // get_oauth_token() succeeds (covered by environment in real runs);
+        // here we exercise the inner branch by priming the cache and calling
+        // error_hint_for with a transcript_path pointing at it.
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript_path = tmp.path().join("transcript.jsonl");
+        std::fs::write(&transcript_path, "").unwrap();
+
+        let empty = crate::usage_limits::UsageLimitsData::default();
+        crate::cache::write_usage_limits(&transcript_path, &empty, 600);
+
+        let ctx = crate::context::Context {
+            transcript_path: Some(transcript_path.to_string_lossy().into()),
+            ..Default::default()
+        };
+        let cfg = crate::config::CshipConfig::default();
+
+        // Skip if no real OAuth credential is present in the environment;
+        // the hint we want exercises the `Ok(_)` arm. CI runs without a
+        // credential, so we guard with the same probe used by error_hint_for.
+        if crate::platform::get_oauth_token().is_err() {
+            return;
+        }
+
+        let (msg, hint) = error_hint_for("usage_limits", &ctx, &cfg);
+        assert!(
+            msg.contains("plan reports no usage windows or extra credits"),
+            "unexpected msg: {msg}"
+        );
+        assert!(
+            hint.contains("Claude Enterprise"),
+            "unexpected hint: {hint}"
         );
     }
 }

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -540,11 +540,11 @@ fn format_extra_usage(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> Option
     } else if lacks_standard_signal(data) {
         let threshold = cfg.warn_threshold.unwrap_or(0.0);
         match data.extra_usage_utilization {
-            Some(u) if u > threshold => "\u{26a1}",
-            _ => "\u{1f4a4}", // 💤
+            Some(u) if u > threshold => "\u{26a1}", // ⚡
+            _ => "\u{1f4a4}",                       // 💤
         }
     } else {
-        "\u{1f4a4}"
+        "\u{1f4a4}" // 💤
     };
     let eu_fmt = cfg
         .extra_usage_format
@@ -2125,7 +2125,10 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("Some");
-        assert_eq!(out, "\u{26a1}", "above warn => lightning bolt");
+        assert_eq!(
+            out, "\u{26a1}", /* ⚡ */
+            "above warn => lightning bolt"
+        );
     }
 
     #[test]
@@ -2143,7 +2146,10 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("Some");
-        assert_eq!(out, "\u{1f4a4}", "below warn => sleep emoji");
+        assert_eq!(
+            out, "\u{1f4a4}", /* 💤 */
+            "below warn => sleep emoji"
+        );
     }
 
     #[test]
@@ -2161,7 +2167,7 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("Some");
-        assert_eq!(out, "\u{26a1}");
+        assert_eq!(out, "\u{26a1}" /* ⚡ */);
     }
 
     #[test]
@@ -2180,7 +2186,7 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("Some");
-        assert_eq!(out, "\u{26a1}");
+        assert_eq!(out, "\u{26a1}" /* ⚡ */);
     }
 
     #[test]

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -518,19 +518,21 @@ fn format_extra_usage(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> Option
         .extra_usage_utilization
         .map(|v| format!("{v:.0}"))
         .unwrap_or_else(|| "?".into());
+    // The Anthropic OAuth usage API reports `used_credits` and `monthly_limit`
+    // in cents (smallest currency unit). Divide by 100 for dollar display.
     let eu_used = data
         .extra_usage_used_credits
-        .map(|v| format!("{v:.0}"))
+        .map(|v| format!("{:.2}", v / 100.0))
         .unwrap_or_else(|| "?".into());
     let eu_limit = data
         .extra_usage_monthly_limit
-        .map(|v| format!("{v:.0}"))
+        .map(|v| format!("{:.2}", v / 100.0))
         .unwrap_or_else(|| "?".into());
     let eu_remaining_credits = match (
         data.extra_usage_monthly_limit,
         data.extra_usage_used_credits,
     ) {
-        (Some(limit), Some(used)) => format!("{:.0}", (limit - used).max(0.0)),
+        (Some(limit), Some(used)) => format!("{:.2}", (limit - used).max(0.0) / 100.0),
         _ => "?".into(),
     };
     let active = if data.five_hour_pct >= 100.0 || data.seven_day_pct >= 100.0 {
@@ -1695,8 +1697,8 @@ mod tests {
             "active indicator (⚡) when 5h at 100%: {result:?}"
         );
         assert!(result.contains("31%"), "extra pct in: {result:?}");
-        assert!(result.contains("6195"), "used credits in: {result:?}");
-        assert!(result.contains("20000"), "monthly limit in: {result:?}");
+        assert!(result.contains("61.95"), "used credits in: {result:?}");
+        assert!(result.contains("200.00"), "monthly limit in: {result:?}");
     }
 
     #[test]
@@ -1790,7 +1792,7 @@ mod tests {
         let result = format_output(&data, &cfg);
         assert!(result.contains("EXTRA 31%"), "custom format: {result:?}");
         assert!(
-            result.contains("rem:13805"),
+            result.contains("rem:138.05"),
             "remaining credits: {result:?}"
         );
     }
@@ -2035,7 +2037,7 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("extra_usage should render");
-        assert!(out.contains("rem=13805"), "remaining_credits: {out:?}");
+        assert!(out.contains("rem=138.05"), "remaining_credits: {out:?}");
         assert!(out.contains("pct=31"), "pct still works: {out:?}");
     }
 
@@ -2064,36 +2066,40 @@ mod tests {
     }
 
     #[test]
-    fn test_format_extra_usage_renders_whole_units() {
-        // Regression: API values are dollars, not cents. Default format must show
-        // $19411 / $20000, not $194 / $200.
+    fn test_format_extra_usage_renders_dollars_from_cents() {
+        // The Anthropic OAuth usage API reports `used_credits` and
+        // `monthly_limit` in cents. Verified against a real Claude Enterprise
+        // response: monthly_limit=30000 cents = $300.00, used=23076 cents =
+        // $230.76. The default format must render those as $230.76 / $300.00.
         let data = UsageLimitsData {
             extra_usage_enabled: Some(true),
-            extra_usage_monthly_limit: Some(20000.0),
-            extra_usage_used_credits: Some(19411.0),
-            extra_usage_utilization: Some(97.055),
+            extra_usage_monthly_limit: Some(30000.0),
+            extra_usage_used_credits: Some(23076.0),
+            extra_usage_utilization: Some(76.92),
             ..Default::default()
         };
         let cfg = UsageLimitsConfig::default();
         let out = format_extra_usage(&data, &cfg).expect("extra_usage enabled => Some");
+        assert!(out.contains("230.76"), "expected $230.76 in output: {out}");
+        assert!(out.contains("300.00"), "expected $300.00 in output: {out}");
         assert!(
-            out.contains("19411"),
-            "expected $19411 in output, got: {out}"
+            !out.contains("23076"),
+            "raw cents must not appear in output: {out}"
         );
         assert!(
-            out.contains("20000"),
-            "expected $20000 in output, got: {out}"
+            !out.contains("30000"),
+            "raw cents must not appear in output: {out}"
         );
-        assert!(!out.contains("$194 "), "must not divide by 100; got: {out}");
     }
 
     #[test]
-    fn test_format_extra_usage_remaining_credits_whole_units() {
+    fn test_format_extra_usage_remaining_credits_dollars_from_cents() {
+        // monthly_limit=30000c, used=23076c → remaining=6924c → $69.24
         let data = UsageLimitsData {
             extra_usage_enabled: Some(true),
-            extra_usage_monthly_limit: Some(20000.0),
-            extra_usage_used_credits: Some(19411.0),
-            extra_usage_utilization: Some(97.055),
+            extra_usage_monthly_limit: Some(30000.0),
+            extra_usage_used_credits: Some(23076.0),
+            extra_usage_utilization: Some(76.92),
             ..Default::default()
         };
         let cfg = UsageLimitsConfig {
@@ -2101,7 +2107,7 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("extra_usage enabled => Some");
-        assert_eq!(out, "rem $589");
+        assert_eq!(out, "rem $69.24");
     }
 
     #[test]
@@ -2203,11 +2209,13 @@ mod tests {
         let transcript_path = tmp.path().join("transcript.jsonl");
         std::fs::write(&transcript_path, "").unwrap();
 
+        // Sourced from a real Claude Enterprise OAuth response —
+        // monthly_limit and used_credits are in cents.
         let data = UsageLimitsData {
             extra_usage_enabled: Some(true),
-            extra_usage_monthly_limit: Some(20000.0),
-            extra_usage_used_credits: Some(19411.0),
-            extra_usage_utilization: Some(97.055),
+            extra_usage_monthly_limit: Some(30000.0),
+            extra_usage_used_credits: Some(23076.0),
+            extra_usage_utilization: Some(76.92),
             ..Default::default()
         };
         crate::cache::write_usage_limits(&transcript_path, &data, 600);
@@ -2220,8 +2228,8 @@ mod tests {
         let out = render(&ctx, &cfg).expect("Enterprise: extra_usage_only must render");
         assert!(!out.contains("5h:"), "must not include 5h section: {out}");
         assert!(!out.contains("7d:"), "must not include 7d section: {out}");
-        assert!(out.contains("19411"), "must include used credits: {out}");
-        assert!(out.contains("20000"), "must include limit: {out}");
+        assert!(out.contains("230.76"), "must include used dollars: {out}");
+        assert!(out.contains("300.00"), "must include limit dollars: {out}");
     }
 
     #[test]

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -496,35 +496,44 @@ fn model_entries<'a>(
 
 /// Format the extra usage section. Returns `None` when extra usage is absent or disabled.
 ///
-/// The `{active}` placeholder renders `"⚡"` when either 5h or 7d utilization is at 100%
-/// (meaning requests are currently consuming extra credits), or `"💤"` otherwise.
+/// `{active}` glyph rules:
+/// - Pro/Max: `⚡` when either 5h or 7d utilization is at 100%, else `💤`.
+/// - Enterprise (no 5h/7d signal): `⚡` once `extra_usage_utilization` exceeds
+///   `warn_threshold`, or for any non-zero utilization when no threshold is
+///   configured. Otherwise `💤`.
 fn format_extra_usage(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> Option<String> {
     if data.extra_usage_enabled != Some(true) {
         return None;
     }
     let eu_pct = data
         .extra_usage_utilization
-        .map(|v| format!("{:.0}", v))
+        .map(|v| format!("{v:.0}"))
         .unwrap_or_else(|| "?".into());
     let eu_used = data
         .extra_usage_used_credits
-        .map(|v| format!("{:.2}", v / 100.0))
+        .map(|v| format!("{v:.0}"))
         .unwrap_or_else(|| "?".into());
     let eu_limit = data
         .extra_usage_monthly_limit
-        .map(|v| format!("{:.0}", v / 100.0))
+        .map(|v| format!("{v:.0}"))
         .unwrap_or_else(|| "?".into());
     let eu_remaining_credits = match (
         data.extra_usage_monthly_limit,
         data.extra_usage_used_credits,
     ) {
-        (Some(limit), Some(used)) => format!("{:.2}", (limit - used).max(0.0) / 100.0),
+        (Some(limit), Some(used)) => format!("{:.0}", (limit - used).max(0.0)),
         _ => "?".into(),
     };
     let active = if data.five_hour_pct >= 100.0 || data.seven_day_pct >= 100.0 {
         "\u{26a1}" // ⚡
+    } else if lacks_standard_signal(data) {
+        let threshold = cfg.warn_threshold.unwrap_or(0.0);
+        match data.extra_usage_utilization {
+            Some(u) if u > threshold => "\u{26a1}",
+            _ => "\u{1f4a4}", // 💤
+        }
     } else {
-        "\u{1f4a4}" // 💤
+        "\u{1f4a4}"
     };
     let eu_fmt = cfg
         .extra_usage_format
@@ -871,7 +880,10 @@ mod tests {
         let styled = apply_threshold("X", &data, &cfg);
         // Critical style should have wrapped the content with ANSI escapes.
         assert_ne!(styled, "X", "expected critical styling to apply");
-        assert!(styled.contains('\x1b'), "expected ANSI escape; got {styled:?}");
+        assert!(
+            styled.contains('\x1b'),
+            "expected ANSI escape; got {styled:?}"
+        );
     }
 
     #[test]
@@ -1674,8 +1686,8 @@ mod tests {
             "active indicator (⚡) when 5h at 100%: {result:?}"
         );
         assert!(result.contains("31%"), "extra pct in: {result:?}");
-        assert!(result.contains("61.95"), "used credits in: {result:?}");
-        assert!(result.contains("200"), "monthly limit in: {result:?}");
+        assert!(result.contains("6195"), "used credits in: {result:?}");
+        assert!(result.contains("20000"), "monthly limit in: {result:?}");
     }
 
     #[test]
@@ -1769,7 +1781,7 @@ mod tests {
         let result = format_output(&data, &cfg);
         assert!(result.contains("EXTRA 31%"), "custom format: {result:?}");
         assert!(
-            result.contains("rem:138.05"),
+            result.contains("rem:13805"),
             "remaining credits: {result:?}"
         );
     }
@@ -2014,7 +2026,7 @@ mod tests {
             ..Default::default()
         };
         let out = format_extra_usage(&data, &cfg).expect("extra_usage should render");
-        assert!(out.contains("rem=138.05"), "remaining_credits: {out:?}");
+        assert!(out.contains("rem=13805"), "remaining_credits: {out:?}");
         assert!(out.contains("pct=31"), "pct still works: {out:?}");
     }
 
@@ -2040,6 +2052,120 @@ mod tests {
             out, "rem={remaining}",
             "literal {{remaining}} should pass through untouched"
         );
+    }
+
+    #[test]
+    fn test_format_extra_usage_renders_whole_units() {
+        // Regression: API values are dollars, not cents. Default format must show
+        // $19411 / $20000, not $194 / $200.
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(19411.0),
+            extra_usage_utilization: Some(97.055),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig::default();
+        let out = format_extra_usage(&data, &cfg).expect("extra_usage enabled => Some");
+        assert!(
+            out.contains("19411"),
+            "expected $19411 in output, got: {out}"
+        );
+        assert!(
+            out.contains("20000"),
+            "expected $20000 in output, got: {out}"
+        );
+        assert!(!out.contains("$194 "), "must not divide by 100; got: {out}");
+    }
+
+    #[test]
+    fn test_format_extra_usage_remaining_credits_whole_units() {
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(19411.0),
+            extra_usage_utilization: Some(97.055),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            extra_usage_format: Some("rem ${remaining_credits}".into()),
+            ..Default::default()
+        };
+        let out = format_extra_usage(&data, &cfg).expect("extra_usage enabled => Some");
+        assert_eq!(out, "rem $589");
+    }
+
+    #[test]
+    fn test_active_glyph_on_enterprise_above_warn() {
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(17000.0),
+            extra_usage_utilization: Some(85.0),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            warn_threshold: Some(80.0),
+            extra_usage_format: Some("{active}".into()),
+            ..Default::default()
+        };
+        let out = format_extra_usage(&data, &cfg).expect("Some");
+        assert_eq!(out, "\u{26a1}", "above warn => lightning bolt");
+    }
+
+    #[test]
+    fn test_active_glyph_on_enterprise_below_warn() {
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(10000.0),
+            extra_usage_utilization: Some(50.0),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            warn_threshold: Some(80.0),
+            extra_usage_format: Some("{active}".into()),
+            ..Default::default()
+        };
+        let out = format_extra_usage(&data, &cfg).expect("Some");
+        assert_eq!(out, "\u{1f4a4}", "below warn => sleep emoji");
+    }
+
+    #[test]
+    fn test_active_glyph_on_enterprise_no_threshold_any_usage() {
+        // No warn_threshold configured — ANY non-zero utilization shows ⚡.
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_utilization: Some(0.1),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(20.0),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            extra_usage_format: Some("{active}".into()),
+            ..Default::default()
+        };
+        let out = format_extra_usage(&data, &cfg).expect("Some");
+        assert_eq!(out, "\u{26a1}");
+    }
+
+    #[test]
+    fn test_active_glyph_pro_max_unchanged_at_5h_full() {
+        // Pre-existing semantic: ⚡ when 5h or 7d at 100%, regardless of extra_usage.
+        let data = UsageLimitsData {
+            five_hour_pct: 100.0,
+            extra_usage_enabled: Some(true),
+            extra_usage_utilization: Some(0.0),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(0.0),
+            ..Default::default()
+        };
+        let cfg = UsageLimitsConfig {
+            extra_usage_format: Some("{active}".into()),
+            ..Default::default()
+        };
+        let out = format_extra_usage(&data, &cfg).expect("Some");
+        assert_eq!(out, "\u{26a1}");
     }
 
     #[test]

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -151,12 +151,19 @@ pub(crate) fn lacks_standard_signal(data: &UsageLimitsData) -> bool {
 }
 
 /// Apply threshold styling using the higher of 5h/7d utilization.
+/// Falls back to `extra_usage_utilization` when both standard signals are zero
+/// (Enterprise plans where 5h/7d data is absent).
 fn apply_threshold(content: &str, data: &UsageLimitsData, cfg: &CshipConfig) -> String {
     let ul_cfg = cfg.usage_limits.as_ref();
-    let max_pct = data.five_hour_pct.max(data.seven_day_pct);
+    let standard_max = data.five_hour_pct.max(data.seven_day_pct);
+    let pct = if standard_max > 0.0 {
+        standard_max
+    } else {
+        data.extra_usage_utilization.unwrap_or(0.0)
+    };
     crate::ansi::apply_style_with_threshold(
         content,
-        Some(max_pct),
+        Some(pct),
         ul_cfg.and_then(|c| c.style.as_deref()),
         ul_cfg.and_then(|c| c.warn_threshold),
         ul_cfg.and_then(|c| c.warn_style.as_deref()),
@@ -842,6 +849,50 @@ mod tests {
             result.contains('\x1b'),
             "expected ANSI codes for critical: {result:?}"
         );
+    }
+
+    // ── apply_threshold() extra_usage fallback tests ─────────────────────────
+
+    #[test]
+    fn test_apply_threshold_uses_extra_usage_when_standard_absent() {
+        use crate::config::CshipConfig;
+        let data = UsageLimitsData {
+            extra_usage_utilization: Some(85.0),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            usage_limits: Some(UsageLimitsConfig {
+                critical_threshold: Some(80.0),
+                critical_style: Some("bold red".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let styled = apply_threshold("X", &data, &cfg);
+        // Critical style should have wrapped the content with ANSI escapes.
+        assert_ne!(styled, "X", "expected critical styling to apply");
+        assert!(styled.contains('\x1b'), "expected ANSI escape; got {styled:?}");
+    }
+
+    #[test]
+    fn test_apply_threshold_prefers_standard_when_present() {
+        use crate::config::CshipConfig;
+        let data = UsageLimitsData {
+            five_hour_pct: 30.0,
+            extra_usage_utilization: Some(90.0),
+            ..Default::default()
+        };
+        let cfg = CshipConfig {
+            usage_limits: Some(UsageLimitsConfig {
+                critical_threshold: Some(80.0),
+                critical_style: Some("bold red".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let styled = apply_threshold("X", &data, &cfg);
+        // Standard pct (30%) is below threshold; extra_usage (90%) is ignored.
+        assert_eq!(styled, "X", "expected no styling; standard signal must win");
     }
 
     // ── fetch_with_timeout() tests ────────────────────────────────────────────

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -172,12 +172,21 @@ fn apply_threshold(content: &str, data: &UsageLimitsData, cfg: &CshipConfig) -> 
     )
 }
 
-/// Render the usage limits module (5h + 7d + per-model + extra usage combined).
+/// Render the usage limits module.
+///
+/// On Pro/Max plans this is the full 5h + 7d (+ optional per-model + optional extra)
+/// composition produced by `format_output`. On Enterprise plans (where the API returns
+/// 5h/7d as null), `render` short-circuits to the `extra_usage` section only.
 pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
     let data = resolve_data(ctx, cfg)?;
     let default_ul_cfg = UsageLimitsConfig::default();
     let ul_cfg = cfg.usage_limits.as_ref().unwrap_or(&default_ul_cfg);
-    let content = format_output(&data, ul_cfg);
+
+    let content = if lacks_standard_signal(&data) {
+        format_extra_usage(&data, ul_cfg)?
+    } else {
+        format_output(&data, ul_cfg)
+    };
     Some(apply_threshold(&content, &data, cfg))
 }
 
@@ -2186,5 +2195,52 @@ mod tests {
         let result = format_output(&data, &cfg);
         assert_eq!(result, "50% | 30%", "no trailing separator: {result:?}");
         assert!(!result.ends_with(" | "), "no dangling sep: {result:?}");
+    }
+
+    #[test]
+    fn test_render_enterprise_extra_usage_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript_path = tmp.path().join("transcript.jsonl");
+        std::fs::write(&transcript_path, "").unwrap();
+
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(true),
+            extra_usage_monthly_limit: Some(20000.0),
+            extra_usage_used_credits: Some(19411.0),
+            extra_usage_utilization: Some(97.055),
+            ..Default::default()
+        };
+        crate::cache::write_usage_limits(&transcript_path, &data, 600);
+
+        let ctx = Context {
+            transcript_path: Some(transcript_path.to_string_lossy().into()),
+            ..Default::default()
+        };
+        let cfg = CshipConfig::default();
+        let out = render(&ctx, &cfg).expect("Enterprise: extra_usage_only must render");
+        assert!(!out.contains("5h:"), "must not include 5h section: {out}");
+        assert!(!out.contains("7d:"), "must not include 7d section: {out}");
+        assert!(out.contains("19411"), "must include used credits: {out}");
+        assert!(out.contains("20000"), "must include limit: {out}");
+    }
+
+    #[test]
+    fn test_render_enterprise_extra_disabled_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript_path = tmp.path().join("transcript.jsonl");
+        std::fs::write(&transcript_path, "").unwrap();
+
+        let data = UsageLimitsData {
+            extra_usage_enabled: Some(false),
+            ..Default::default()
+        };
+        crate::cache::write_usage_limits(&transcript_path, &data, 600);
+
+        let ctx = Context {
+            transcript_path: Some(transcript_path.to_string_lossy().into()),
+            ..Default::default()
+        };
+        let cfg = CshipConfig::default();
+        assert!(render(&ctx, &cfg).is_none());
     }
 }

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -136,6 +136,20 @@ fn fetch_and_cache(
     }
 }
 
+/// True when the response carries no 5h or 7d signal — i.e. percentages and
+/// reset markers are all at their `Default` zero state. On Claude Enterprise
+/// the API returns these fields as `null`, so they remain at default values
+/// after `parse_api_response`. Used to switch the renderer into "extra-usage
+/// only" mode.
+pub(crate) fn lacks_standard_signal(data: &UsageLimitsData) -> bool {
+    data.five_hour_pct == 0.0
+        && data.seven_day_pct == 0.0
+        && data.five_hour_resets_at_epoch.is_none()
+        && data.seven_day_resets_at_epoch.is_none()
+        && data.five_hour_resets_at.is_empty()
+        && data.seven_day_resets_at.is_empty()
+}
+
 /// Apply threshold styling using the higher of 5h/7d utilization.
 fn apply_threshold(content: &str, data: &UsageLimitsData, cfg: &CshipConfig) -> String {
     let ul_cfg = cfg.usage_limits.as_ref();
@@ -649,6 +663,41 @@ mod tests {
             seven_day_resets_at: "2099-01-01T00:00:00Z".into(),
             ..Default::default()
         }
+    }
+
+    // ── lacks_standard_signal() tests ────────────────────────────────────────
+
+    #[test]
+    fn test_lacks_standard_signal_returns_true_for_default() {
+        let data = UsageLimitsData::default();
+        assert!(lacks_standard_signal(&data));
+    }
+
+    #[test]
+    fn test_lacks_standard_signal_returns_false_when_pct_set() {
+        let data = UsageLimitsData {
+            five_hour_pct: 1.0,
+            ..Default::default()
+        };
+        assert!(!lacks_standard_signal(&data));
+    }
+
+    #[test]
+    fn test_lacks_standard_signal_returns_false_when_reset_iso_set() {
+        let data = UsageLimitsData {
+            seven_day_resets_at: "2099-01-01T00:00:00+00:00".into(),
+            ..Default::default()
+        };
+        assert!(!lacks_standard_signal(&data));
+    }
+
+    #[test]
+    fn test_lacks_standard_signal_returns_false_when_reset_epoch_set() {
+        let data = UsageLimitsData {
+            five_hour_resets_at_epoch: Some(1_700_000_000),
+            ..Default::default()
+        };
+        assert!(!lacks_standard_signal(&data));
     }
 
     // ── render() tests ────────────────────────────────────────────────────────

--- a/src/usage_limits.rs
+++ b/src/usage_limits.rs
@@ -57,8 +57,8 @@ pub struct UsageLimitsData {
 /// Intermediate struct matching the raw API response structure.
 #[derive(serde::Deserialize)]
 struct ApiResponse {
-    five_hour: UsagePeriod,
-    seven_day: UsagePeriod,
+    five_hour: Option<UsagePeriod>,
+    seven_day: Option<UsagePeriod>,
     seven_day_opus: Option<UsagePeriod>,
     seven_day_sonnet: Option<UsagePeriod>,
     seven_day_cowork: Option<UsagePeriod>,
@@ -99,11 +99,20 @@ fn parse_api_response(json: &str) -> Result<UsageLimitsData, String> {
     let (cowork_pct, cowork_reset) = map_period(&api.seven_day_cowork);
     let (oauth_apps_pct, oauth_apps_reset) = map_period(&api.seven_day_oauth_apps);
 
+    let (five_h_pct, five_h_reset) = api
+        .five_hour
+        .map(|p| (p.utilization, p.resets_at.unwrap_or_default()))
+        .unwrap_or((0.0, String::new()));
+    let (seven_d_pct, seven_d_reset) = api
+        .seven_day
+        .map(|p| (p.utilization, p.resets_at.unwrap_or_default()))
+        .unwrap_or((0.0, String::new()));
+
     Ok(UsageLimitsData {
-        five_hour_pct: api.five_hour.utilization,
-        seven_day_pct: api.seven_day.utilization,
-        five_hour_resets_at: api.five_hour.resets_at.unwrap_or_default(),
-        seven_day_resets_at: api.seven_day.resets_at.unwrap_or_default(),
+        five_hour_pct: five_h_pct,
+        seven_day_pct: seven_d_pct,
+        five_hour_resets_at: five_h_reset,
+        seven_day_resets_at: seven_d_reset,
         five_hour_resets_at_epoch: None,
         seven_day_resets_at_epoch: None,
         extra_usage_enabled: api.extra_usage.as_ref().and_then(|e| e.is_enabled),
@@ -201,5 +210,56 @@ mod tests {
         assert!(data.extra_usage_monthly_limit.is_none());
         assert!(data.seven_day_opus_pct.is_none());
         assert!(data.seven_day_sonnet_pct.is_none());
+    }
+
+    #[test]
+    fn test_parse_enterprise_response_with_null_standard_fields() {
+        // Reproduces the Enterprise API shape: standard fields all null,
+        // extra_usage populated. Sourced from issue #173.
+        let json = r#"{
+            "five_hour": null,
+            "seven_day": null,
+            "seven_day_oauth_apps": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null,
+            "seven_day_cowork": null,
+            "seven_day_omelette": null,
+            "tangelo": null,
+            "iguana_necktie": null,
+            "omelette_promotional": {"utilization": 0.0, "resets_at": null},
+            "extra_usage": {
+                "is_enabled": true,
+                "monthly_limit": 20000,
+                "used_credits": 19411.0,
+                "utilization": 97.055,
+                "currency": "USD"
+            }
+        }"#;
+        let data = parse_api_response(json).expect("Enterprise response must parse");
+        assert_eq!(data.five_hour_pct, 0.0);
+        assert_eq!(data.seven_day_pct, 0.0);
+        assert!(data.five_hour_resets_at.is_empty());
+        assert!(data.seven_day_resets_at.is_empty());
+        assert_eq!(data.extra_usage_enabled, Some(true));
+        assert_eq!(data.extra_usage_monthly_limit, Some(20000.0));
+        assert!((data.extra_usage_used_credits.unwrap() - 19411.0).abs() < f64::EPSILON);
+        assert!((data.extra_usage_utilization.unwrap() - 97.055).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_response_with_missing_standard_fields_keys() {
+        // Future-proofing: even if the API drops these keys entirely, parse must succeed.
+        let json = r#"{
+            "extra_usage": {
+                "is_enabled": true,
+                "monthly_limit": 5000,
+                "used_credits": 1234.5,
+                "utilization": 24.69
+            }
+        }"#;
+        let data = parse_api_response(json).expect("missing standard fields must not be fatal");
+        assert_eq!(data.five_hour_pct, 0.0);
+        assert_eq!(data.seven_day_pct, 0.0);
+        assert_eq!(data.extra_usage_enabled, Some(true));
     }
 }


### PR DESCRIPTION
## Summary

Adds Claude Enterprise support to `cship.usage_limits`. Closes #173.

On Enterprise plans the OAuth usage API returns `five_hour` / `seven_day` as `null` and reports usage exclusively via `extra_usage`. Previously this caused the entire deserializer to reject the response, leaving `cship.usage_limits` permanently empty.

### Changes

- **Parser** (`src/usage_limits.rs`): make `five_hour` and `seven_day` optional in `ApiResponse` so the Enterprise shape parses cleanly.
- **Render** (`src/modules/usage_limits.rs`): when 5h/7d signal is absent, render only the `extra_usage` line; threshold styling falls back to `extra_usage_utilization`; `{active}` glyph reflects Enterprise state.
- **Explain** (`src/explain.rs`): replace the misleading "API fetch failed" hint with Enterprise-aware messages — one for "no extra credits enabled", one for per-model sub-tokens (`.opus`, `.sonnet`, etc.) which don't exist on Enterprise.
- **Docs**: short Enterprise subsection in `docs/configuration.md` plus a FAQ entry.

### Test plan

- [x] `cargo test` — 404 lib + 68 integration tests pass (8 new + 1 revised tests covering the parser, render, threshold fallback, explain hints, and `{active}` glyph behaviour).
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- [x] Verified on a live Claude Enterprise account — status line renders `⚡ 81% ($243.29/$300.00)` with proper threshold styling.

<details>

```toml
[cship]
lines = [
  "$directory$git_branch$git_status$python$nodejs$rust",
  "$cship.model $cship.cost $cship.context_bar $cship.context_window $cship.usage_limits"
]

[cship.model]
symbol = " " # nf-fa-microchip
style  = "bold fg:#7aa2f7"

[cship.context_bar]
symbol             = " " # nf-fa-database
format             = "[$symbol$value]($style)"
width              = 10
style              = "fg:#7dcfff"
warn_threshold     = 40.0
warn_style         = "fg:#e0af68"
critical_threshold = 70.0
critical_style     = "bold fg:#f7768e"

[cship.cost]
symbol             = "💰 "
style              = "fg:#a9b1d6"
warn_threshold     = 2.0
warn_style         = "fg:#e0af68"
critical_threshold = 5.0
critical_style     = "bold fg:#f7768e"

[cship.usage_limits]
five_hour_format   = "⌛ 5h {pct}%"
seven_day_format   = "📅 7d {pct}%"
#separator          = " "
warn_threshold     = 70.0
warn_style         = "fg:#e0af68"
critical_threshold = 90.0
critical_style     = "bold fg:#f7768e"
extra_usage_format = "{active} ${used}/${limit} ({pct}%)"
ttl                = 120

[cship.context_window]
format = "[$cship.context_window.used_percentage$cship.context_window.remaining_percentage]($style)"
warn_threshold     = 40.0
warn_style         = "fg:#e0af68"
critical_threshold = 70.0
critical_style     = "bold fg:#f7768e"

[cship.context_window.used_percentage]
symbol = "ctx "
format = "[$symbol$value%]($style)"
style  = "fg:#7dcfff"

[cship.context_window.remaining_percentage]
symbol = " left "
format = "[$symbol$value%]($style)"
style  = "fg:#7dcfff"
invert_threshold = true   # warn when remaining is LOW
warn_threshold     = 30.0
warn_style         = "fg:#e0af68"
critical_threshold = 15.0
critical_style     = "bold fg:#f7768e"
```

</details>


<img width="755" height="83" alt="image" src="https://github.com/user-attachments/assets/500107ce-f17b-4ab3-a48a-81df9b5ec571" />




Fixes #173 