### PR TITLE
chore(ci): update GitHub Actions to latest majors (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,10 @@ jobs:
     name: Build VitePress site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
         working-directory: docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Copy installer scripts to public
         run: |
@@ -48,9 +48,10 @@ jobs:
         working-directory: docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages
@@ -62,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate version format
         env:
           VERSION: ${{ github.event.inputs.version }}
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -91,7 +91,7 @@ jobs:
           - target: aarch64-pc-windows-msvc
             runner: windows-11-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -115,7 +115,7 @@ jobs:
           if [[ "${{ matrix.target }}" == *windows* ]]; then EXT=".exe"; fi
           if [[ "${{ matrix.target }}" != *windows* ]]; then file "cship-${{ matrix.target }}"; fi
           test -s "cship-${{ matrix.target }}${EXT}" || { echo "ERROR: binary is empty"; exit 1; }
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cship-${{ matrix.target }}
           path: cship-${{ matrix.target }}*
@@ -128,10 +128,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.version || github.ref_name }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
       - name: Extract changelog for this release
         shell: bash
         env:
@@ -149,7 +149,7 @@ jobs:
           if [ ! -s /tmp/release-notes.md ]; then
             echo "See commit history for changes in this release." > /tmp/release-notes.md
           fi
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           files: cship-*/cship-*
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.version || github.ref_name }}
       - name: Install Rust stable


### PR DESCRIPTION
## Summary

Closes #171. Silences the `Node.js 20 actions are deprecated...` warning that fires on every CI run, and gets ahead of the **2026-09-16** Node 20 removal from runners.

All actions bumped to their latest major:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

`Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`, and `anthropics/claude-code-action@v1` are floating tags and already current — left untouched.

### One non-version-bump change

`actions/upload-pages-artifact@v4+` excludes dotfiles by default. VitePress writes `.nojekyll` to its `dist/` output, and GitHub Pages needs that file to serve the `_assets/` folder. So `docs.yml` also gets:

```yaml
- uses: actions/upload-pages-artifact@v5
  with:
    path: docs/.vitepress/dist
    include-hidden-files: true   # NEW — keep .nojekyll in the artifact
```

## Test plan

- [ ] CI passes on this PR across `ubuntu-latest`, `macos-latest`, `windows-latest`
- [ ] No `##[warning]Node.js 20 actions are deprecated...` line in the run logs
- [ ] (Post-merge) `docs.yml` succeeds on the next `v*` tag and the docs site loads CSS/JS — confirms `.nojekyll` shipped
- [ ] (Post-merge) `release.yml` succeeds on the next release — confirms the `upload-artifact@v7` ↔ `download-artifact@v8` pair works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)