### PR TITLE
fix(ci): repair tag-push release path; drop docs tag trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Deploy Docs
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 # Allow one concurrent deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     needs: test
+    if: "!cancelled() && needs.test.result == 'success'"
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
## Why
The v1.7.0 tag push exposed two latent CI bugs that had been hidden because every prior release used `workflow_dispatch` (Run workflow → enter version), not a direct tag push.

### 1. Release pipeline skipped build/publish ([run](https://github.com/stephenleo/cship/actions/runs/25627644282))
- Tests ran across all 3 OSes ✅
- `Build`, `Publish GitHub Release`, `Publish to crates.io` all **skipped**
- Cause: the `build` job had no explicit `if:`. With the implicit `success()` and the upstream `tag` job skipped (its `if:` requires `workflow_dispatch`), `success()` evaluated false and `build` skipped — cascading into `release` and `publish`.

### 2. Docs deploy rejected by environment policy ([run](https://github.com/stephenleo/cship/actions/runs/25627644286))
- VitePress build succeeded; deploy step rejected with: *"Tag v1.7.0 is not allowed to deploy to github-pages due to environment protection rules."*
- The `github-pages` environment's deployment-branch policy permits only `main`. Every prior docs deploy was a manual `workflow_dispatch` from main; the tag path had never fired before.

## What
- **release.yml**: add `if: "!cancelled() && needs.test.result == 'success'"` to the `build` job — the same pattern already used by `release` and `publish`. Restores the tag-push release path.
- **docs.yml**: drop `push: tags: ['v*']`, keep `workflow_dispatch` only. Preserves the existing manual-publish workflow and avoids fighting the environment policy.

## Recovery plan for v1.7.0 (after this merges)
1. Delete the orphan tag on origin: `git push origin :refs/tags/v1.7.0` (and `git tag -d v1.7.0` locally)
2. Trigger release: `gh workflow run release.yml -f version=v1.7.0`
3. Trigger docs: `gh workflow run "Deploy Docs"`

## Test plan
- [ ] Existing CI passes on this PR
- [ ] After recovery: GitHub Release v1.7.0 has 6 binaries attached
- [ ] After recovery: crates.io shows cship 1.7.0
- [ ] After recovery: cship.dev reflects v1.7.0 docs