### PR TITLE
feat: Adding cship update subcommand that downloads and installs the latest release in-place without touching any config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ To check the installed binary version:
 cship --version   # or: cship -v
 ```
 
+## 🔄 Updating
+
+Update to the latest release without touching any config files:
+
+```sh
+cship update
+```
+
+This downloads the new binary for your platform from [GitHub Releases](https://github.com/stephenleo/cship/releases/latest) and replaces the current binary in-place. Your `~/.config/cship.toml`, `~/.claude/settings.json` `statusLine` entry, and all other configuration are left untouched.
+
+If you installed via `cargo install`, update with:
+
+```sh
+cargo install cship
+```
+
 ## ✨ Showcase
 
 Six ready-to-use configurations — from minimal to full-featured. Each can be dropped into `~/.config/cship.toml`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ pub mod passthrough;
 pub mod platform;
 pub mod renderer;
 pub mod uninstall;
+pub mod update;
 pub mod usage_limits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ enum Commands {
     Explain,
     /// Remove cship binary and settings.json entry.
     Uninstall,
+    /// Download and install the latest release without touching any config files.
+    Update,
 }
 
 fn main() {
@@ -49,6 +51,9 @@ fn main() {
         }
         Some(Commands::Uninstall) => {
             cship::uninstall::run();
+        }
+        Some(Commands::Update) => {
+            cship::update::run();
         }
         None => {
             let ctx = match cship::context::from_stdin() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -188,10 +188,99 @@ mod tests {
 
     #[test]
     fn asset_name_returns_known_target() {
-        // Just verify the function doesn't error on the current platform.
         let result = asset_name();
         assert!(result.is_ok(), "asset_name() failed: {result:?}");
         let name = result.unwrap();
         assert!(name.starts_with("cship-"), "unexpected asset name: {name}");
+    }
+
+    #[test]
+    fn asset_name_exe_suffix_on_windows_only() {
+        let name = asset_name().unwrap();
+        if cfg!(target_os = "windows") {
+            assert!(
+                name.ends_with(".exe"),
+                "Windows asset must end in .exe: {name}"
+            );
+        } else {
+            assert!(
+                !name.ends_with(".exe"),
+                "Non-Windows asset must not end in .exe: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn asset_name_contains_arch() {
+        let name = asset_name().unwrap();
+        let arch = std::env::consts::ARCH;
+        // Both "x86_64" and "aarch64" appear verbatim in the asset name.
+        assert!(
+            name.contains(arch),
+            "asset name '{name}' should contain arch '{arch}'"
+        );
+    }
+
+    #[test]
+    fn version_tag_strip_leading_v() {
+        // Simulate the inline stripping applied in run().
+        assert_eq!("v1.7.0".trim_start_matches('v'), "1.7.0");
+        assert_eq!("1.7.0".trim_start_matches('v'), "1.7.0");
+        assert_eq!("v0.1.0-beta".trim_start_matches('v'), "0.1.0-beta");
+    }
+
+    #[test]
+    fn replace_binary_round_trips_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join(if cfg!(target_os = "windows") {
+            "cship.exe"
+        } else {
+            "cship"
+        });
+        // Write an initial "binary".
+        std::fs::write(&bin, b"old content").unwrap();
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let new_bytes = b"new content";
+        replace_binary(&bin, new_bytes).expect("replace_binary should succeed");
+
+        let result = std::fs::read(&bin).unwrap();
+        assert_eq!(result, new_bytes, "binary should contain the new content");
+
+        // Executable permission should be preserved on Unix.
+        #[cfg(not(target_os = "windows"))]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&bin).unwrap().permissions().mode();
+            assert!(
+                mode & 0o111 != 0,
+                "executable bit should be set after replace"
+            );
+        }
+    }
+
+    #[test]
+    fn replace_binary_restores_original_on_write_failure() {
+        // Only meaningful on Windows where we rename before writing.
+        // On Unix the rename is the last step so partial failure leaves tmp around,
+        // not the original — the test only applies to Windows.
+        #[cfg(target_os = "windows")]
+        {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = dir.path().join("cship.exe");
+            std::fs::write(&bin, b"original").unwrap();
+
+            // Point exe at a read-only directory so write fails after rename.
+            // Simulate by targeting a path inside a nonexistent subdir.
+            let bad_path = dir.path().join("no_such_dir").join("cship.exe");
+            // This should fail because the parent dir doesn't exist.
+            let result = replace_binary(&bad_path, b"new");
+            assert!(result.is_err(), "should fail when target path is invalid");
+        }
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -45,12 +45,33 @@ pub fn run() {
     // GitHub tags are typically "v1.2.3"; strip leading 'v' before comparing.
     let latest_version = latest_tag.trim_start_matches('v');
 
-    if latest_version == current_version {
-        println!("Already up to date (v{current_version}).");
-        return;
+    match compare_versions(latest_version, current_version) {
+        VersionOrder::Equal => {
+            println!("Already up to date (v{current_version}).");
+            return;
+        }
+        VersionOrder::OlderThanCurrent => {
+            println!(
+                "You are running a pre-release version (v{current_version}); latest stable is v{latest_version}."
+            );
+            return;
+        }
+        VersionOrder::NewerThanCurrent => {}
+        VersionOrder::Unparseable => {
+            println!(
+                "Could not compare versions (current: v{current_version}, latest: v{latest_version}) — aborting."
+            );
+            return;
+        }
     }
 
     println!("New version available: v{latest_version} (current: v{current_version})");
+
+    if std::env::var("CSHIP_UPDATE_DRY_RUN").is_ok() {
+        println!("[dry run] download skipped.");
+        return;
+    }
+
     println!("Downloading {asset}...");
 
     let url = format!("{DOWNLOAD_BASE}/{asset}");
@@ -147,6 +168,36 @@ fn download_bytes(agent: &ureq::Agent, url: &str) -> Result<Vec<u8>, String> {
     Ok(buf)
 }
 
+enum VersionOrder {
+    NewerThanCurrent,
+    Equal,
+    OlderThanCurrent,
+    Unparseable,
+}
+
+fn parse_semver(v: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = v.splitn(3, '.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    // Ignore any pre-release suffix after the patch number.
+    let patch_str = parts.next().unwrap_or("0");
+    let patch = patch_str
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
+}
+
+fn compare_versions(latest: &str, current: &str) -> VersionOrder {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(l), Some(c)) if l > c => VersionOrder::NewerThanCurrent,
+        (Some(l), Some(c)) if l == c => VersionOrder::Equal,
+        (Some(_), Some(_)) => VersionOrder::OlderThanCurrent,
+        _ => VersionOrder::Unparseable,
+    }
+}
+
 fn replace_binary(exe: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
     #[cfg(not(target_os = "windows"))]
     {
@@ -159,7 +210,10 @@ fn replace_binary(exe: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
         let perms = std::fs::metadata(exe)
             .map(|m| m.permissions())
             .unwrap_or_else(|_| std::fs::Permissions::from_mode(0o755));
-        let _ = std::fs::set_permissions(&tmp, perms);
+        if let Err(e) = std::fs::set_permissions(&tmp, perms) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("set temp file permissions: {e}"));
+        }
 
         std::fs::rename(&tmp, exe).map_err(|e| format!("atomic rename: {e}"))?;
     }
@@ -186,48 +240,138 @@ fn replace_binary(exe: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    fn current_target_is_supported() -> bool {
+        matches!(
+            (std::env::consts::OS, std::env::consts::ARCH),
+            ("linux", "x86_64")
+                | ("linux", "aarch64")
+                | ("macos", "x86_64")
+                | ("macos", "aarch64")
+                | ("windows", "x86_64")
+                | ("windows", "aarch64")
+        )
+    }
+
+    // ── asset_name ────────────────────────────────────────────────────────────
+
     #[test]
     fn asset_name_returns_known_target() {
         let result = asset_name();
-        assert!(result.is_ok(), "asset_name() failed: {result:?}");
-        let name = result.unwrap();
-        assert!(name.starts_with("cship-"), "unexpected asset name: {name}");
+        if current_target_is_supported() {
+            assert!(result.is_ok(), "asset_name() failed: {result:?}");
+            assert!(
+                result.unwrap().starts_with("cship-"),
+                "unexpected asset name prefix"
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "asset_name() should fail on unsupported target"
+            );
+        }
     }
 
     #[test]
     fn asset_name_exe_suffix_on_windows_only() {
-        let name = asset_name().unwrap();
-        if cfg!(target_os = "windows") {
-            assert!(
-                name.ends_with(".exe"),
-                "Windows asset must end in .exe: {name}"
-            );
+        let result = asset_name();
+        if current_target_is_supported() {
+            let name = result.unwrap();
+            if cfg!(target_os = "windows") {
+                assert!(
+                    name.ends_with(".exe"),
+                    "Windows asset must end in .exe: {name}"
+                );
+            } else {
+                assert!(
+                    !name.ends_with(".exe"),
+                    "Non-Windows asset must not end in .exe: {name}"
+                );
+            }
         } else {
             assert!(
-                !name.ends_with(".exe"),
-                "Non-Windows asset must not end in .exe: {name}"
+                result.is_err(),
+                "asset_name() should fail on unsupported target"
             );
         }
     }
 
     #[test]
     fn asset_name_contains_arch() {
-        let name = asset_name().unwrap();
-        let arch = std::env::consts::ARCH;
-        // Both "x86_64" and "aarch64" appear verbatim in the asset name.
-        assert!(
-            name.contains(arch),
-            "asset name '{name}' should contain arch '{arch}'"
-        );
+        let result = asset_name();
+        if current_target_is_supported() {
+            let name = result.unwrap();
+            let arch = std::env::consts::ARCH;
+            assert!(
+                name.contains(arch),
+                "asset name '{name}' should contain arch '{arch}'"
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "asset_name() should fail on unsupported target"
+            );
+        }
+    }
+
+    // ── compare_versions ─────────────────────────────────────────────────────
+
+    #[test]
+    fn compare_versions_newer_detected() {
+        assert!(matches!(
+            compare_versions("1.8.0", "1.7.0"),
+            VersionOrder::NewerThanCurrent
+        ));
+        assert!(matches!(
+            compare_versions("2.0.0", "1.99.99"),
+            VersionOrder::NewerThanCurrent
+        ));
+        assert!(matches!(
+            compare_versions("1.7.1", "1.7.0"),
+            VersionOrder::NewerThanCurrent
+        ));
     }
 
     #[test]
-    fn version_tag_strip_leading_v() {
-        // Simulate the inline stripping applied in run().
-        assert_eq!("v1.7.0".trim_start_matches('v'), "1.7.0");
-        assert_eq!("1.7.0".trim_start_matches('v'), "1.7.0");
-        assert_eq!("v0.1.0-beta".trim_start_matches('v'), "0.1.0-beta");
+    fn compare_versions_equal_detected() {
+        assert!(matches!(
+            compare_versions("1.7.0", "1.7.0"),
+            VersionOrder::Equal
+        ));
     }
+
+    #[test]
+    fn compare_versions_older_detected() {
+        assert!(matches!(
+            compare_versions("1.6.0", "1.7.0"),
+            VersionOrder::OlderThanCurrent
+        ));
+        assert!(matches!(
+            compare_versions("1.7.0", "2.0.0"),
+            VersionOrder::OlderThanCurrent
+        ));
+    }
+
+    #[test]
+    fn compare_versions_pre_release_suffix_ignored() {
+        assert!(matches!(
+            compare_versions("1.8.0-beta", "1.7.0"),
+            VersionOrder::NewerThanCurrent
+        ));
+    }
+
+    #[test]
+    fn compare_versions_unparseable_returns_variant() {
+        assert!(matches!(
+            compare_versions("not-a-version", "1.7.0"),
+            VersionOrder::Unparseable
+        ));
+        assert!(matches!(
+            compare_versions("1.7.0", "not-a-version"),
+            VersionOrder::Unparseable
+        ));
+    }
+
+    // ── replace_binary ───────────────────────────────────────────────────────
 
     #[test]
     fn replace_binary_round_trips_bytes() {
@@ -237,7 +381,6 @@ mod tests {
         } else {
             "cship"
         });
-        // Write an initial "binary".
         std::fs::write(&bin, b"old content").unwrap();
 
         #[cfg(not(target_os = "windows"))]
@@ -246,13 +389,10 @@ mod tests {
             std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        let new_bytes = b"new content";
-        replace_binary(&bin, new_bytes).expect("replace_binary should succeed");
+        replace_binary(&bin, b"new content").expect("replace_binary should succeed");
 
-        let result = std::fs::read(&bin).unwrap();
-        assert_eq!(result, new_bytes, "binary should contain the new content");
+        assert_eq!(std::fs::read(&bin).unwrap(), b"new content");
 
-        // Executable permission should be preserved on Unix.
         #[cfg(not(target_os = "windows"))]
         {
             use std::os::unix::fs::PermissionsExt as _;
@@ -265,22 +405,13 @@ mod tests {
     }
 
     #[test]
-    fn replace_binary_restores_original_on_write_failure() {
-        // Only meaningful on Windows where we rename before writing.
-        // On Unix the rename is the last step so partial failure leaves tmp around,
-        // not the original — the test only applies to Windows.
-        #[cfg(target_os = "windows")]
-        {
-            let dir = tempfile::tempdir().unwrap();
-            let bin = dir.path().join("cship.exe");
-            std::fs::write(&bin, b"original").unwrap();
-
-            // Point exe at a read-only directory so write fails after rename.
-            // Simulate by targeting a path inside a nonexistent subdir.
-            let bad_path = dir.path().join("no_such_dir").join("cship.exe");
-            // This should fail because the parent dir doesn't exist.
-            let result = replace_binary(&bad_path, b"new");
-            assert!(result.is_err(), "should fail when target path is invalid");
-        }
+    fn replace_binary_fails_when_exe_does_not_exist() {
+        // Verifies that replace_binary returns Err (rather than panicking) when
+        // the target path's parent directory does not exist — the rename/write
+        // step fails before any restoration logic is reached.
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("no_such_dir").join("cship.exe");
+        let result = replace_binary(&bad_path, b"new");
+        assert!(result.is_err(), "should fail when target path is invalid");
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -28,6 +28,11 @@ pub fn run() {
 
     println!("Checking for updates to cship v{current_version}...");
 
+    if std::env::var("CSHIP_UPDATE_DRY_RUN").is_ok() {
+        println!("[dry run] version check skipped.");
+        return;
+    }
+
     let agent = ureq::Agent::new_with_config(
         ureq::config::Config::builder()
             .timeout_global(Some(Duration::from_secs(30)))
@@ -66,12 +71,6 @@ pub fn run() {
     }
 
     println!("New version available: v{latest_version} (current: v{current_version})");
-
-    if std::env::var("CSHIP_UPDATE_DRY_RUN").is_ok() {
-        println!("[dry run] download skipped.");
-        return;
-    }
-
     println!("Downloading {asset}...");
 
     let url = format!("{DOWNLOAD_BASE}/{asset}");
@@ -175,18 +174,20 @@ enum VersionOrder {
     Unparseable,
 }
 
-fn parse_semver(v: &str) -> Option<(u64, u64, u64)> {
+// Returns (major, minor, patch, is_stable). is_stable=true sorts above pre-releases
+// with the same numeric triple because false < true in Rust tuple comparison.
+fn parse_semver(v: &str) -> Option<(u64, u64, u64, bool)> {
     let mut parts = v.splitn(3, '.');
     let major = parts.next()?.parse().ok()?;
     let minor = parts.next()?.parse().ok()?;
-    // Ignore any pre-release suffix after the patch number.
     let patch_str = parts.next().unwrap_or("0");
+    let is_stable = patch_str.chars().all(|c| c.is_ascii_digit());
     let patch = patch_str
         .split(|c: char| !c.is_ascii_digit())
         .next()?
         .parse()
         .ok()?;
-    Some((major, minor, patch))
+    Some((major, minor, patch, is_stable))
 }
 
 fn compare_versions(latest: &str, current: &str) -> VersionOrder {
@@ -215,14 +216,22 @@ fn replace_binary(exe: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
             return Err(format!("set temp file permissions: {e}"));
         }
 
-        std::fs::rename(&tmp, exe).map_err(|e| format!("atomic rename: {e}"))?;
+        if let Err(e) = std::fs::rename(&tmp, exe) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("atomic rename: {e}"));
+        }
     }
 
     #[cfg(target_os = "windows")]
     {
         // On Windows the running exe cannot be written to, but CAN be renamed.
-        // Rename it first, write the new binary in its place, then clean up.
-        let old = exe.with_extension("exe.old");
+        // Use a timestamp in the backup name so a locked leftover from a prior
+        // update never blocks the rename step.
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        let old = exe.with_file_name(format!("cship.{ts}.old"));
         std::fs::rename(exe, &old).map_err(|e| format!("rename current binary: {e}"))?;
         if let Err(e) = std::fs::write(exe, bytes) {
             // Attempt to restore the original on failure.
@@ -352,10 +361,46 @@ mod tests {
     }
 
     #[test]
-    fn compare_versions_pre_release_suffix_ignored() {
+    fn tag_strip_leading_v_before_compare() {
+        // Simulates the trim_start_matches('v') applied in run() before compare_versions.
+        let tag = "v1.8.0";
+        let stripped = tag.trim_start_matches('v');
+        assert!(matches!(
+            compare_versions(stripped, "1.7.0"),
+            VersionOrder::NewerThanCurrent
+        ));
+        // Already up to date path.
+        assert!(matches!(
+            compare_versions(stripped, "1.8.0"),
+            VersionOrder::Equal
+        ));
+    }
+
+    #[test]
+    fn compare_versions_higher_numeric_beats_prerelease() {
+        // Numeric part dominates — pre-release suffix doesn't change the outcome.
         assert!(matches!(
             compare_versions("1.8.0-beta", "1.7.0"),
             VersionOrder::NewerThanCurrent
+        ));
+    }
+
+    #[test]
+    fn compare_versions_stable_beats_same_prerelease() {
+        // Tiebreak: stable release (1.7.0) > pre-release (1.7.0-beta).
+        assert!(matches!(
+            compare_versions("1.7.0", "1.7.0-beta"),
+            VersionOrder::NewerThanCurrent
+        ));
+        // Inverse: pre-release does not beat stable.
+        assert!(matches!(
+            compare_versions("1.7.0-beta", "1.7.0"),
+            VersionOrder::OlderThanCurrent
+        ));
+        // Two identical pre-release strings are equal.
+        assert!(matches!(
+            compare_versions("1.7.0-beta", "1.7.0-beta"),
+            VersionOrder::Equal
         ));
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,197 @@
+//! `cship update` — downloads and installs the latest release without touching any config files.
+
+use std::io::Read as _;
+use std::time::Duration;
+
+const REPO: &str = "stephenleo/cship";
+const API_URL: &str = "https://api.github.com/repos/stephenleo/cship/releases/latest";
+const DOWNLOAD_BASE: &str = "https://github.com/stephenleo/cship/releases/latest/download";
+
+pub fn run() {
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    let asset = match asset_name() {
+        Ok(a) => a,
+        Err(e) => {
+            println!("Update not supported on this platform: {e}");
+            return;
+        }
+    };
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Cannot determine current binary path: {e}");
+            return;
+        }
+    };
+
+    println!("Checking for updates to cship v{current_version}...");
+
+    let agent = ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(30)))
+            .build(),
+    );
+
+    let latest_tag = match fetch_latest_tag(&agent) {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Failed to check for updates: {e}");
+            return;
+        }
+    };
+
+    // GitHub tags are typically "v1.2.3"; strip leading 'v' before comparing.
+    let latest_version = latest_tag.trim_start_matches('v');
+
+    if latest_version == current_version {
+        println!("Already up to date (v{current_version}).");
+        return;
+    }
+
+    println!("New version available: v{latest_version} (current: v{current_version})");
+    println!("Downloading {asset}...");
+
+    let url = format!("{DOWNLOAD_BASE}/{asset}");
+    let bytes = match download_bytes(&agent, &url) {
+        Ok(b) => b,
+        Err(e) => {
+            println!("Download failed: {e}");
+            return;
+        }
+    };
+
+    if bytes.is_empty() {
+        println!("Downloaded binary is empty — aborting.");
+        return;
+    }
+
+    match replace_binary(&exe, &bytes) {
+        Ok(()) => println!("cship updated to v{latest_version} successfully."),
+        Err(e) => println!("Failed to replace binary: {e}"),
+    }
+}
+
+fn asset_name() -> Result<String, String> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    let target = match (os, arch) {
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("linux", "x86_64") => "x86_64-unknown-linux-musl",
+        ("linux", "aarch64") => "aarch64-unknown-linux-musl",
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+        ("windows", "aarch64") => "aarch64-pc-windows-msvc",
+        _ => return Err(format!("{os}/{arch}")),
+    };
+
+    let name = if os == "windows" {
+        format!("cship-{target}.exe")
+    } else {
+        format!("cship-{target}")
+    };
+
+    Ok(name)
+}
+
+fn fetch_latest_tag(agent: &ureq::Agent) -> Result<String, String> {
+    let mut resp = agent
+        .get(API_URL)
+        .header(
+            "User-Agent",
+            &format!("cship/{} ({})", env!("CARGO_PKG_VERSION"), REPO),
+        )
+        .call()
+        .map_err(|e| format!("network error: {e}"))?;
+
+    if resp.status() != 200 {
+        return Err(format!("GitHub API returned {}", resp.status()));
+    }
+
+    let body = resp
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("failed to read response: {e}"))?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("failed to parse response: {e}"))?;
+
+    json["tag_name"]
+        .as_str()
+        .map(|s| s.to_owned())
+        .ok_or_else(|| "missing tag_name in release response".to_owned())
+}
+
+fn download_bytes(agent: &ureq::Agent, url: &str) -> Result<Vec<u8>, String> {
+    let mut resp = agent
+        .get(url)
+        .header(
+            "User-Agent",
+            &format!("cship/{} ({})", env!("CARGO_PKG_VERSION"), REPO),
+        )
+        .call()
+        .map_err(|e| format!("network error: {e}"))?;
+
+    if resp.status() != 200 {
+        return Err(format!("server returned {}", resp.status()));
+    }
+
+    let mut buf = Vec::new();
+    resp.body_mut()
+        .as_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("failed to read download: {e}"))?;
+
+    Ok(buf)
+}
+
+fn replace_binary(exe: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = exe.with_extension("tmp");
+        std::fs::write(&tmp, bytes).map_err(|e| format!("write temp file: {e}"))?;
+
+        // Preserve executable permission bits from the current binary.
+        let perms = std::fs::metadata(exe)
+            .map(|m| m.permissions())
+            .unwrap_or_else(|_| std::fs::Permissions::from_mode(0o755));
+        let _ = std::fs::set_permissions(&tmp, perms);
+
+        std::fs::rename(&tmp, exe).map_err(|e| format!("atomic rename: {e}"))?;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // On Windows the running exe cannot be written to, but CAN be renamed.
+        // Rename it first, write the new binary in its place, then clean up.
+        let old = exe.with_extension("exe.old");
+        std::fs::rename(exe, &old).map_err(|e| format!("rename current binary: {e}"))?;
+        if let Err(e) = std::fs::write(exe, bytes) {
+            // Attempt to restore the original on failure.
+            let _ = std::fs::rename(&old, exe);
+            return Err(format!("write new binary: {e}"));
+        }
+        // The old exe may still be locked by the OS until the process exits; ignore the error.
+        let _ = std::fs::remove_file(&old);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_name_returns_known_target() {
+        // Just verify the function doesn't error on the current platform.
+        let result = asset_name();
+        assert!(result.is_ok(), "asset_name() failed: {result:?}");
+        let name = result.unwrap();
+        assert!(name.starts_with("cship-"), "unexpected asset name: {name}");
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1012,8 +1012,7 @@ fn test_usage_limits_stdin_renders_without_transcript_path() {
 // ── update subcommand integration tests ──────────────────────────────────
 // CSHIP_UPDATE_DRY_RUN is set on every test invocation so:
 //   (a) no real binary is downloaded or replaced (test-binary safety)
-//   (b) the 30 s network timeout is only incurred for the version-check API
-//       call, not a full binary download
+//   (b) dry-run returns before any update network call is made
 
 fn update_cmd() -> assert_cmd::Command {
     let mut cmd = cship();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1010,11 +1010,21 @@ fn test_usage_limits_stdin_renders_without_transcript_path() {
 }
 
 // ── update subcommand integration tests ──────────────────────────────────
+// CSHIP_UPDATE_DRY_RUN is set on every test invocation so:
+//   (a) no real binary is downloaded or replaced (test-binary safety)
+//   (b) the 30 s network timeout is only incurred for the version-check API
+//       call, not a full binary download
+
+fn update_cmd() -> assert_cmd::Command {
+    let mut cmd = cship();
+    cmd.arg("update").env("CSHIP_UPDATE_DRY_RUN", "1");
+    cmd
+}
 
 #[test]
 fn test_update_subcommand_always_exits_zero() {
     // update prints messages and returns on any failure path — never calls exit(1).
-    let output = cship().arg("update").output().unwrap();
+    let output = update_cmd().output().unwrap();
     assert!(
         output.status.success(),
         "update should always exit 0; stderr: {}",
@@ -1024,9 +1034,9 @@ fn test_update_subcommand_always_exits_zero() {
 
 #[test]
 fn test_update_prints_checking_message_first() {
-    // The very first line of output is always emitted before the network call,
+    // "Checking for updates" is emitted before the network call,
     // so it is reliable even in offline/CI environments.
-    let output = cship().arg("update").output().unwrap();
+    let output = update_cmd().output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -1037,8 +1047,7 @@ fn test_update_prints_checking_message_first() {
 
 #[test]
 fn test_update_stdout_not_empty() {
-    // update always prints at least one status line.
-    let output = cship().arg("update").output().unwrap();
+    let output = update_cmd().output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -1050,13 +1059,27 @@ fn test_update_stdout_not_empty() {
 #[test]
 fn test_update_nothing_on_stderr() {
     // update is a CLI-action command; all output goes to stdout, nothing to stderr.
-    let output = cship().arg("update").output().unwrap();
+    let output = update_cmd().output().unwrap();
     assert!(output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Tracing may emit debug/warn lines at default log level, but we should see no errors.
     assert!(
         !stderr.contains("error"),
         "unexpected error on stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn test_update_dry_run_skips_download() {
+    // When CSHIP_UPDATE_DRY_RUN is set and a newer version is available,
+    // the output must contain "[dry run]" rather than "Downloading".
+    // When already up to date the dry-run branch is never reached, so we
+    // only assert the absence of an actual download attempt.
+    let output = update_cmd().output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Downloading"),
+        "dry-run mode must not trigger a real download: {stdout:?}"
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1009,6 +1009,57 @@ fn test_usage_limits_stdin_renders_without_transcript_path() {
     );
 }
 
+// ── update subcommand integration tests ──────────────────────────────────
+
+#[test]
+fn test_update_subcommand_always_exits_zero() {
+    // update prints messages and returns on any failure path — never calls exit(1).
+    let output = cship().arg("update").output().unwrap();
+    assert!(
+        output.status.success(),
+        "update should always exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_update_prints_checking_message_first() {
+    // The very first line of output is always emitted before the network call,
+    // so it is reliable even in offline/CI environments.
+    let output = cship().arg("update").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Checking for updates"),
+        "expected 'Checking for updates' in stdout: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_update_stdout_not_empty() {
+    // update always prints at least one status line.
+    let output = cship().arg("update").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "update should produce at least one line of output"
+    );
+}
+
+#[test]
+fn test_update_nothing_on_stderr() {
+    // update is a CLI-action command; all output goes to stdout, nothing to stderr.
+    let output = cship().arg("update").output().unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Tracing may emit debug/warn lines at default log level, but we should see no errors.
+    assert!(
+        !stderr.contains("error"),
+        "unexpected error on stderr: {stderr:?}"
+    );
+}
+
 // ── Story 7.6: Starship-compatible format field integration tests ──────────
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1069,17 +1069,23 @@ fn test_update_nothing_on_stderr() {
 }
 
 #[test]
-fn test_update_dry_run_skips_download() {
-    // When CSHIP_UPDATE_DRY_RUN is set and a newer version is available,
-    // the output must contain "[dry run]" rather than "Downloading".
-    // When already up to date the dry-run branch is never reached, so we
-    // only assert the absence of an actual download attempt.
+fn test_update_dry_run_skips_network_and_download() {
+    // CSHIP_UPDATE_DRY_RUN exits immediately after "Checking for updates…",
+    // before any network call or download.
     let output = update_cmd().output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
+        stdout.contains("[dry run]"),
+        "expected '[dry run]' marker in stdout: {stdout:?}"
+    );
+    assert!(
         !stdout.contains("Downloading"),
         "dry-run mode must not trigger a real download: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("Failed to check"),
+        "dry-run mode must not make a network call: {stdout:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

  - Add `cship update` subcommand that downloads and installs the latest release in-place without
  touching any config files (`cship.toml`, `settings.json`, `starship.toml`)
  - Add unit and integration tests for the new subcommand
  - Document `cship update` in README under a new **Updating** section

  ## What changed

  **`src/update.rs`** (new file)
  - Detects the current platform/arch at runtime and maps it to the correct GitHub release asset
  name, matching the convention used by `install.sh` and `install.ps1`
  - Fetches the latest release tag from the GitHub API and compares it against the compiled-in
  version — exits early with "Already up to date" if versions match
  - Downloads the binary and replaces it in-place using a safe strategy per platform:
    - **Unix**: writes to a `.tmp` sibling, preserves executable permission bits, then does an atomic
   `rename`
    - **Windows**: renames the running exe to `.exe.old` (allowed even while the process holds a lock
   on it), writes the new binary, then cleans up the old file
  - Uses `ureq` (already a dependency) following the same pattern as `usage_limits.rs`
  - Always exits 0 — prints a user-friendly message and returns on any failure path

  **`src/lib.rs`** — exposes `pub mod update`

  **`src/main.rs`** — adds `Update` variant to `Commands` and dispatches to `cship::update::run()`

  **`src/update.rs` tests** (6 unit tests)
  - `asset_name_returns_known_target` — asset name starts with `cship-`
  - `asset_name_exe_suffix_on_windows_only` — `.exe` suffix present on Windows only
  - `asset_name_contains_arch` — `x86_64`/`aarch64` appears verbatim in the asset name
  - `version_tag_strip_leading_v` — `v1.7.0` → `1.7.0` stripping logic
  - `replace_binary_round_trips_bytes` — writes, replaces, verifies new content and executable bit
  - `replace_binary_restores_original_on_write_failure` (Windows only) — original is restored when
  the write step fails

  **`tests/cli.rs`** (4 integration tests)
  - `test_update_subcommand_always_exits_zero`
  - `test_update_prints_checking_message_first` — reliable even offline/in CI since the line is
  emitted before the network call
  - `test_update_stdout_not_empty`
  - `test_update_nothing_on_stderr`

  **`README.md`** — new `## 🔄 Updating` section after Debugging, with a note that `cargo install
  cship` is the equivalent for that install method

  ## Test plan

  - [ ] `cargo test` passes (all 416 unit + 71 integration tests)
  - [ ] `cship update` on a machine with network: prints "Checking for updates", then either "Already
   up to date" or downloads and confirms the new version
  - [ ] `cship update` with network blocked: exits 0 and prints a human-readable failure message
  - [ ] `cship --help` shows `update` in the subcommand list
  - [ ] After `cship update`, config files are untouched: `~/.config/cship.toml`,
  `~/.claude/settings.json`