### PR TITLE
style(docs): center hero and split tagline to match README

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -10,3 +10,30 @@
     'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
 }
+
+.VPHero .container {
+  justify-content: center;
+}
+
+.VPHero .main {
+  text-align: center;
+}
+
+.VPHero .heading {
+  align-items: center;
+  justify-content: center;
+}
+
+.VPHero .text {
+  font-size: 28px;
+  line-height: 36px;
+}
+
+.VPHero .actions {
+  justify-content: center;
+}
+
+.VPHero .tagline {
+  margin: 0 auto;
+  font-style: italic;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: "⚓ CShip"
-  text: ""
-  tagline: A beautiful, fully customizable statusline for Claude Code — Starship-style TOML config, themeable colours, Nerd Font glyphs, and tunable cost/context/usage thresholds.
+  text: "A beautiful, fully customizable statusline for Claude Code"
+  tagline: Starship-style TOML config, themeable colours, Nerd Font glyphs, and tunable cost/context/usage thresholds.
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
## Summary
- Centers the docs site hero (title, subtitle, tagline, action buttons) using `align-items: center` on `.VPHero .heading` and `margin: 0 auto` on `.tagline`
- Splits the long tagline into a bold subtitle (28px, via the VitePress `text` hero field) plus an italic tagline (via `tagline`) so the docs hierarchy matches the README's bold + italic split
- Keeps `⚓ CShip` as the largest element so it remains the primary heading

## Test plan
- [x] `npm run docs:dev` — verified hero centered and subtitle smaller than title in browser
- [ ] Confirm post-merge docs deploy renders the same on https://cship.dev

🤖 Generated with [Claude Code](https://claude.ai/code)