### PR TITLE
style(docs): drop hero tagline and promote subtitle

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -24,9 +24,8 @@
   justify-content: center;
 }
 
-.VPHero .text {
-  font-size: 28px;
-  line-height: 36px;
+.VPHero .tagline {
+  margin: 0 auto;
 }
 
 .VPHero .actions {

--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -32,8 +32,3 @@
 .VPHero .actions {
   justify-content: center;
 }
-
-.VPHero .tagline {
-  margin: 0 auto;
-  font-style: italic;
-}

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@ layout: home
 hero:
   name: "⚓ CShip"
   text: "A beautiful, fully customizable statusline for Claude Code"
-  tagline: Starship-style TOML config, themeable colours, Nerd Font glyphs, and tunable cost/context/usage thresholds.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: "⚓ CShip"
-  text: "A beautiful, fully customizable statusline for Claude Code"
+  tagline: "A beautiful, fully customizable statusline for Claude Code"
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
## Summary
- Removes the Starship/colours/glyphs italic tagline from the docs hero
- Promotes "A beautiful, fully customizable statusline for Claude Code" to be the new `tagline:` (was previously the bold `text:` subtitle)
- Drops the now-unused `.VPHero .text` font-size override; adds `margin: 0 auto` to `.VPHero .tagline` so the muted tagline stays centered under the title

## Test plan
- [x] Verified locally via `npm run docs:dev` — title + tagline centered, hero image centered below
- [ ] Confirm post-merge docs deploy on https://cship.dev

🤖 Generated with [Claude Code](https://claude.ai/code)