### PR TITLE
fix(docs): align showcase with README and restore missing Nerd Font glyphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ install_private.sh
 .DS_Store
 marketing/
 skills-lock.json
+.playwright-mcp/

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -9,7 +9,7 @@ Ready-to-use `cship.toml` configurations — from the recommended full-featured 
 
 My personal setup, end to end. Top row: `$starship_prompt` running Starship's [Catppuccin Powerline preset](https://starship.rs/presets/catppuccin-powerline). Bottom row: model, cost, context bar, 7-day per-model usage, extra credits, peak-hours indicator — thresholds escalate cool → warn → critical as budgets fill.
 
-![Hero cship statusline](./examples/hero.gif)
+![Hero cship statusline](./examples/01.png)
 
 **`~/.config/cship.toml`**
 
@@ -21,11 +21,11 @@ lines = [
 ]
 
 [cship.model]
-symbol = " "
+symbol = " "
 style  = "bold cyan"
 
 [cship.context_bar]
-symbol             = " "
+symbol             = " "
 filled_char        = "●"
 empty_char         = "○"
 format             = "[$symbol$value]($style)"


### PR DESCRIPTION
## Summary

- Replace `hero.gif` with `01.png` in the docs showcase hero image to match the README
- Restore the missing U+F2DB (nf-fa-microchip) and U+F1C0 (nf-fa-database) Nerd Font glyphs in the Hero config block — they had been silently dropped, leaving a plain space
- Add `.playwright-mcp/` to `.gitignore`

## Test plan

- [ ] Visit `/showcase` on the deployed docs site and confirm the Hero image matches the README
- [ ] Confirm `[cship.model]` and `[cship.context_bar]` symbol values in the Hero config block render Nerd Font icons (requires Nerd Font in browser via the bundled woff2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)