### PR TITLE
fix(docs): restore missing Nerd Font glyphs in Hero usage_limits formats

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -45,8 +45,8 @@ critical_threshold = 50
 critical_style     = "bold fg:#f7768e"
 
 [cship.usage_limits]
-five_hour_format   = " 5h {pct}% ({reset})"
-seven_day_format   = " 7d {pct}% ({reset})"
+five_hour_format   = " 5h {pct}% ({reset})"
+seven_day_format   = " 7d {pct}% ({reset})"
 separator          = " "
 warn_threshold     = 50.0
 warn_style         = "fg:#e0af68"


### PR DESCRIPTION
## Summary

- Restores `nf-fa-clock` (U+F017) in `five_hour_format` and `nf-fa-calendar` (U+F073) in `seven_day_format` in the Hero showcase config — both had been silently replaced with a plain space, so those lines showed no icon on the docs site

Follow-up to #185 which caught the `symbol` glyphs; these were in the format strings.

## Test plan

- [ ] Visit `/showcase` on the deployed docs site, open the Hero config block, confirm the `five_hour_format` and `seven_day_format` lines render clock and calendar icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)