### PR TITLE
feat(effort): add $cship.effort reasoning-effort module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Added the `cship.effort` module (`$cship.effort` / `$cship.effort.level`), which displays the session's reasoning effort level (`low`/`medium`/`high`/`xhigh`/`max`) and reflects mid-session `/effort` changes. Supports per-level styling via `low_style` / `medium_style` / `high_style` / `xhigh_style` / `max_style`, each falling back to `style`. Renders nothing when the active model does not support the effort parameter ([#187](https://github.com/stephenleo/cship/issues/187))
+
 ## [1.7.1] - 2026-05-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Ready-to-use configurations — from the recommended full-featured setup down to
 
 ### 1. ⚓ Hero / Recommended
 
-My personal setup, end to end. Top row: `$starship_prompt` running Starship's [Catppuccin Powerline preset](https://starship.rs/presets/catppuccin-powerline). Bottom row: model, cost, context bar, 7-day per-model usage, extra credits, peak-hours indicator — thresholds escalate cool → warn → critical as budgets fill.
+My personal setup, end to end. Top row: `$starship_prompt` running Starship's [Catppuccin Powerline preset](https://starship.rs/presets/catppuccin-powerline). Bottom row: model, effort, cost, context bar, 7-day per-model usage, extra credits, peak-hours indicator — thresholds escalate cool → warn → critical as budgets fill.
 
 <img src="./docs/examples/01.png" alt="Hero cship statusline example" width="600">
 
@@ -147,12 +147,19 @@ My personal setup, end to end. Top row: `$starship_prompt` running Starship's [C
 [cship]
 lines = [
   "$starship_prompt",
-  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage",
+  "$cship.model $cship.effort $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage",
 ]
 
 [cship.model]
 symbol = " "
 style  = "bold cyan"
+
+[cship.effort]
+symbol      = "⚡ "
+style       = "fg:#7dcfff"
+high_style  = "fg:#e0af68"
+xhigh_style = "bold fg:#e0af68"
+max_style   = "bold fg:#f7768e"
 
 [cship.context_bar]
 symbol             = " "

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Everything in the [Claude Code status line documentation](https://code.claude.co
 | `$cship.usage_limits.extra_usage` | Extra-credits section with `{active}` indicator |
 | `$cship.peak_usage` | Peak-time indicator (US Pacific business hours) |
 | `$cship.agent` | Sub-agent name |
+| `$cship.effort` | Reasoning effort level (`low`/`medium`/`high`/`xhigh`/`max`) |
 | `$cship.session` | Session identity info |
 | `$cship.workspace` | Workspace/project directory |
 

--- a/cship.toml
+++ b/cship.toml
@@ -1,12 +1,19 @@
 [cship]
 lines = [
   "$starship_prompt",
-  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage"
+  "$cship.model $cship.effort $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage"
 ]
 
 [cship.model]
 symbol = " "
 style  = "bold cyan"
+
+[cship.effort]
+symbol      = "⚡ "
+style       = "fg:#7dcfff"
+high_style  = "fg:#e0af68"
+xhigh_style = "bold fg:#e0af68"
+max_style   = "bold fg:#f7768e"
 
 [cship.context_bar]
 symbol             = " "

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,6 +287,39 @@ style  = "fg:#9ece6a"
 
 ---
 
+## `[cship.effort]` — Reasoning Effort
+
+Displays the current reasoning effort level (`low`, `medium`, `high`, `xhigh`, or `max`), reflecting mid-session `/effort` changes. Returns nothing when the active model does not support the effort parameter.
+
+**Token:** `$cship.effort` (alias for `$cship.effort.level`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `disabled` | `bool` | `false` | Hide this module |
+| `style` | `string` | — | Base ANSI style (fallback when no per-level style matches) |
+| `symbol` | `string` | — | Prefix symbol |
+| `format` | `string` | — | Format string; `$value` = effort level |
+| `low_style` | `string` | — | Style applied when the level is `low` |
+| `medium_style` | `string` | — | Style applied when the level is `medium` |
+| `high_style` | `string` | — | Style applied when the level is `high` |
+| `xhigh_style` | `string` | — | Style applied when the level is `xhigh` |
+| `max_style` | `string` | — | Style applied when the level is `max` |
+
+**Variables:** `$value` (effort level, e.g. `high`), `$symbol`, `$style`
+
+Per-level styles are matched case-insensitively against the effort level. When no per-level style matches or is set, `style` is used as the fallback.
+
+```toml
+[cship.effort]
+symbol      = "⚡ "
+style       = "dim"
+high_style  = "yellow"
+xhigh_style = "bold yellow"
+max_style   = "bold red"
+```
+
+---
+
 ## `[cship.session]` — Session Identity
 
 Displays session metadata (session ID, transcript path, output style, cship version).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -94,6 +94,14 @@ not enabled on your Enterprise account).
 
 ---
 
+## Why does `$cship.effort` show nothing?
+
+The `effort` module renders the session's reasoning effort level, which Claude Code only sends when the **active model supports the effort parameter**. If you're on a model without effort support, the field is absent and the module renders nothing — switch to a model that supports `/effort` (or run `cship explain` to confirm whether an `effort` value is present in the context).
+
+The value reflects live `/effort` changes, so it updates on the next render after you change it mid-session.
+
+---
+
 ## How does the peak-time indicator handle time zones and DST?
 
 The `peak_usage` module checks whether the current time falls within the configured peak window in **US Pacific time**. It computes the UTC→Pacific offset internally — PDT (UTC−7) from the second Sunday of March through the first Sunday of November, PST (UTC−8) the rest of the year.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -7,7 +7,7 @@ Ready-to-use `cship.toml` configurations — from the recommended full-featured 
 
 ## 1. Hero / Recommended
 
-My personal setup, end to end. Top row: `$starship_prompt` running Starship's [Catppuccin Powerline preset](https://starship.rs/presets/catppuccin-powerline). Bottom row: model, cost, context bar, 7-day per-model usage, extra credits, peak-hours indicator — thresholds escalate cool → warn → critical as budgets fill.
+My personal setup, end to end. Top row: `$starship_prompt` running Starship's [Catppuccin Powerline preset](https://starship.rs/presets/catppuccin-powerline). Bottom row: model, effort, cost, context bar, 7-day per-model usage, extra credits, peak-hours indicator — thresholds escalate cool → warn → critical as budgets fill.
 
 ![Hero cship statusline](./examples/01.png)
 
@@ -17,12 +17,19 @@ My personal setup, end to end. Top row: `$starship_prompt` running Starship's [C
 [cship]
 lines = [
   "$starship_prompt",
-  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage",
+  "$cship.model $cship.effort $cship.cost $cship.context_bar $cship.usage_limits $cship.peak_usage",
 ]
 
 [cship.model]
 symbol = " "
 style  = "bold cyan"
+
+[cship.effort]
+symbol      = "⚡ "
+style       = "fg:#7dcfff"
+high_style  = "fg:#e0af68"
+xhigh_style = "bold fg:#e0af68"
+max_style   = "bold fg:#f7768e"
 
 [cship.context_bar]
 symbol             = " "

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct CshipConfig {
     pub context_window: Option<ContextWindowConfig>,
     pub vim: Option<VimConfig>,
     pub agent: Option<AgentConfig>,
+    pub effort: Option<EffortConfig>,
     pub session: Option<SessionConfig>,
     pub workspace: Option<WorkspaceConfig>,
     pub usage_limits: Option<UsageLimitsConfig>,
@@ -239,6 +240,25 @@ pub struct AgentConfig {
     pub disabled: Option<bool>,
     pub label: Option<String>,
     pub format: Option<String>,
+}
+
+/// Configuration for `[cship.effort]` — reasoning effort level display.
+///
+/// Per-level styles (`low_style`, `medium_style`, …) are matched against the
+/// effort level (`low`/`medium`/`high`/`xhigh`/`max`); each falls back to the
+/// base `style` when unset, mirroring `[cship.model]`'s per-family styles.
+#[derive(Debug, Deserialize, Default)]
+pub struct EffortConfig {
+    pub style: Option<String>,
+    pub symbol: Option<String>,
+    pub disabled: Option<bool>,
+    pub label: Option<String>,
+    pub format: Option<String>,
+    pub low_style: Option<String>,
+    pub medium_style: Option<String>,
+    pub high_style: Option<String>,
+    pub xhigh_style: Option<String>,
+    pub max_style: Option<String>,
 }
 
 /// Configuration for session identity modules (cwd, session_id, transcript_path, etc.).

--- a/src/context.rs
+++ b/src/context.rs
@@ -23,6 +23,9 @@ pub struct Context {
     pub vim: Option<Vim>,
     /// Absent unless --agent flag or agent settings are active.
     pub agent: Option<Agent>,
+    /// Reasoning effort level for the session. Absent when the current model does
+    /// not support the effort parameter; reflects mid-session `/effort` changes.
+    pub effort: Option<Effort>,
     /// Rate limits sent directly by Claude Code via stdin (Pro/Max subscribers).
     /// When present, the usage_limits module uses this instead of making an OAuth API call.
     pub rate_limits: Option<RateLimits>,
@@ -96,6 +99,12 @@ pub struct Vim {
 #[derive(Debug, Deserialize, Default)]
 pub struct Agent {
     pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Effort {
+    /// "low", "medium", "high", "xhigh", or "max".
+    pub level: Option<String>,
 }
 
 /// Deserialize Claude Code session JSON from any reader.
@@ -178,6 +187,8 @@ mod tests {
             ctx.agent.as_ref().unwrap().name.as_deref(),
             Some("security-reviewer")
         );
+        // Effort
+        assert_eq!(ctx.effort.as_ref().unwrap().level.as_deref(), Some("high"));
         // Rate limits
         let rl = ctx.rate_limits.as_ref().unwrap();
         let five = rl.five_hour.as_ref().unwrap();
@@ -193,6 +204,7 @@ mod tests {
         let ctx: Context = serde_json::from_str(MINIMAL_JSON).unwrap();
         assert!(ctx.vim.is_none());
         assert!(ctx.agent.is_none());
+        assert!(ctx.effort.is_none());
         assert!(ctx.context_window.is_none());
         assert_eq!(ctx.cost.as_ref().unwrap().total_cost_usd, Some(0.53));
     }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -167,6 +167,11 @@ fn is_disabled(name: &str, cfg: &crate::config::CshipConfig) -> bool {
             .unwrap_or(false),
         "vim" => cfg.vim.as_ref().and_then(|m| m.disabled).unwrap_or(false),
         "agent" => cfg.agent.as_ref().and_then(|m| m.disabled).unwrap_or(false),
+        "effort" => cfg
+            .effort
+            .as_ref()
+            .and_then(|m| m.disabled)
+            .unwrap_or(false),
         "cwd" | "session_id" | "transcript_path" | "version" | "output_style" => cfg
             .session
             .as_ref()
@@ -221,6 +226,10 @@ fn error_hint_for(
         "agent" => (
             "agent data absent — no agent session active".into(),
             "Agent data is only present during agent sessions. Start an agent session or use the --agent flag.".into(),
+        ),
+        "effort" => (
+            "effort data absent — the active model may not support the effort parameter".into(),
+            "The effort level appears only on models that support the reasoning-effort parameter. Switch to such a model, or adjust it mid-session with /effort.".into(),
         ),
         "cwd" | "session_id" | "transcript_path" | "version" | "output_style" => (
             "session field absent from Claude Code context".into(),
@@ -309,6 +318,7 @@ fn config_section_for(module_name: &str, cfg: &crate::config::CshipConfig) -> &'
         "context_window" if cfg.context_window.is_some() => "[cship.context_window]",
         "vim" if cfg.vim.is_some() => "[cship.vim]",
         "agent" if cfg.agent.is_some() => "[cship.agent]",
+        "effort" if cfg.effort.is_some() => "[cship.effort]",
         "cwd" | "session_id" | "transcript_path" | "version" | "output_style"
             if cfg.session.is_some() =>
         {
@@ -386,6 +396,47 @@ mod tests {
     fn test_config_section_for_model_without_config() {
         let cfg = CshipConfig::default();
         assert_eq!(config_section_for("cship.model", &cfg), "(default)");
+    }
+
+    #[test]
+    fn test_config_section_for_effort_with_config() {
+        let cfg = CshipConfig {
+            effort: Some(crate::config::EffortConfig::default()),
+            ..Default::default()
+        };
+        // Both the alias and the sub-token resolve to the [cship.effort] section.
+        assert_eq!(config_section_for("cship.effort", &cfg), "[cship.effort]");
+        assert_eq!(
+            config_section_for("cship.effort.level", &cfg),
+            "[cship.effort]"
+        );
+    }
+
+    #[test]
+    fn test_effort_disabled_detected() {
+        let cfg = CshipConfig {
+            effort: Some(crate::config::EffortConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(is_disabled("cship.effort", &cfg));
+        // The hint should report the explicit-disable case, not the absent-data case.
+        let (status, _) = error_hint_for("cship.effort", &Context::default(), &cfg);
+        assert!(status.contains("disabled"), "status: {status}");
+    }
+
+    #[test]
+    fn test_effort_absent_hint_mentions_model_support() {
+        // No effort config, no effort in context → effort-specific absent hint.
+        let (status, _) =
+            error_hint_for("cship.effort", &Context::default(), &CshipConfig::default());
+        assert!(status.contains("effort"), "status: {status}");
+        assert!(
+            status.contains("model"),
+            "expected the hint to mention model support: {status}"
+        );
     }
 
     #[test]

--- a/src/modules/effort.rs
+++ b/src/modules/effort.rs
@@ -5,8 +5,10 @@
 //! `xhigh`, or `max`), reflecting mid-session `/effort` changes.
 //!
 //! The effort field is absent whenever the current model does not support the
-//! reasoning-effort parameter; like the other optional modules (vim, agent) the
-//! module returns `None` with a `tracing::warn!` in that case.
+//! reasoning-effort parameter — a routine state, not an error. The module
+//! therefore returns `None` and logs at `tracing::debug!` (mirroring
+//! `context_bar`'s treatment of normally-absent data) rather than warning on
+//! every render for users on models without effort support.
 use crate::config::{CshipConfig, EffortConfig};
 use crate::context::Context;
 
@@ -41,11 +43,13 @@ pub fn render_level(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
         return None;
     }
 
-    // Extract value — WARN before returning None (do NOT use `?` here)
+    // Extract value — log before returning None (do NOT use `?` here). Absence is
+    // the normal state when the active model lacks effort support, so this logs at
+    // debug rather than warn (cf. context_bar's normally-absent handling).
     let level = match ctx.effort.as_ref().and_then(|e| e.level.as_deref()) {
         Some(l) => l,
         None => {
-            tracing::warn!("cship.effort: effort.level absent from context");
+            tracing::debug!("cship.effort: effort.level absent from context");
             return None;
         }
     };
@@ -150,11 +154,38 @@ mod tests {
     }
 
     #[test]
+    fn test_per_level_style_low() {
+        let ctx = ctx_with_effort("low");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("low", Some("green")),
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_medium() {
+        let ctx = ctx_with_effort("medium");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("medium", Some("cyan")),
+        );
+    }
+
+    #[test]
     fn test_per_level_style_high() {
         let ctx = ctx_with_effort("high");
         assert_eq!(
             render(&ctx, &per_level_cfg()).unwrap(),
             ansi::apply_style("high", Some("yellow")),
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_xhigh() {
+        let ctx = ctx_with_effort("xhigh");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("xhigh", Some("bold yellow")),
         );
     }
 
@@ -208,5 +239,19 @@ mod tests {
     fn test_no_style_returns_plain_text() {
         let ctx = ctx_with_effort("medium");
         assert_eq!(render(&ctx, &CshipConfig::default()).unwrap(), "medium");
+    }
+
+    #[test]
+    fn test_format_string_substitutes_value_and_symbol() {
+        let ctx = ctx_with_effort("high");
+        let cfg = CshipConfig {
+            effort: Some(EffortConfig {
+                symbol: Some("⚡".to_string()),
+                format: Some("$symbol $value".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), Some("⚡ high".to_string()));
     }
 }

--- a/src/modules/effort.rs
+++ b/src/modules/effort.rs
@@ -1,0 +1,212 @@
+//! Render the `[cship.effort]` module.
+//!
+//! `$cship.effort` — convenience alias for `$cship.effort.level`.
+//! `$cship.effort.level` — raw reasoning-effort string (`low`, `medium`, `high`,
+//! `xhigh`, or `max`), reflecting mid-session `/effort` changes.
+//!
+//! The effort field is absent whenever the current model does not support the
+//! reasoning-effort parameter; like the other optional modules (vim, agent) the
+//! module returns `None` with a `tracing::warn!` in that case.
+use crate::config::{CshipConfig, EffortConfig};
+use crate::context::Context;
+
+/// Resolve the effective style for the current effort level, preferring the
+/// matching per-level style over the base `style`. Matching is case-insensitive
+/// so that an unexpected-cased level from a future Claude Code version still maps.
+fn resolve_effort_style<'a>(level: &str, cfg: Option<&'a EffortConfig>) -> Option<&'a str> {
+    let cfg = cfg?;
+    let per_level = match level.to_lowercase().as_str() {
+        "low" => cfg.low_style.as_deref(),
+        "medium" => cfg.medium_style.as_deref(),
+        "high" => cfg.high_style.as_deref(),
+        "xhigh" => cfg.xhigh_style.as_deref(),
+        "max" => cfg.max_style.as_deref(),
+        _ => None,
+    };
+    per_level.or(cfg.style.as_deref())
+}
+
+/// Renders `$cship.effort` — convenience alias for the effort level.
+pub fn render(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    render_level(ctx, cfg)
+}
+
+/// Renders `$cship.effort.level` — raw effort string with optional symbol, style,
+/// and per-level style escalation.
+pub fn render_level(ctx: &Context, cfg: &CshipConfig) -> Option<String> {
+    let effort_cfg = cfg.effort.as_ref();
+
+    // Disabled check — SILENT (no warn, no log)
+    if effort_cfg.and_then(|e| e.disabled).unwrap_or(false) {
+        return None;
+    }
+
+    // Extract value — WARN before returning None (do NOT use `?` here)
+    let level = match ctx.effort.as_ref().and_then(|e| e.level.as_deref()) {
+        Some(l) => l,
+        None => {
+            tracing::warn!("cship.effort: effort.level absent from context");
+            return None;
+        }
+    };
+
+    let symbol = effort_cfg.and_then(|e| e.symbol.as_deref());
+    let style = resolve_effort_style(level, effort_cfg);
+
+    // Format string takes priority if configured
+    if let Some(fmt) = effort_cfg.and_then(|e| e.format.as_deref()) {
+        return crate::format::apply_module_format(fmt, Some(level), symbol, style);
+    }
+
+    // Default behavior — `{symbol}{level}` with the resolved style applied
+    let symbol_str = symbol.unwrap_or("");
+    let content = format!("{symbol_str}{level}");
+    Some(crate::ansi::apply_style(&content, style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ansi;
+    use crate::config::{CshipConfig, EffortConfig};
+    use crate::context::{Context, Effort};
+
+    fn ctx_with_effort(level: &str) -> Context {
+        Context {
+            effort: Some(Effort {
+                level: Some(level.to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn per_level_cfg() -> CshipConfig {
+        CshipConfig {
+            effort: Some(EffortConfig {
+                style: Some("dim".to_string()),
+                low_style: Some("green".to_string()),
+                medium_style: Some("cyan".to_string()),
+                high_style: Some("yellow".to_string()),
+                xhigh_style: Some("bold yellow".to_string()),
+                max_style: Some("bold red".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_effort_renders_level_string() {
+        let ctx = ctx_with_effort("high");
+        let result = render(&ctx, &CshipConfig::default());
+        assert_eq!(result, Some("high".to_string()));
+    }
+
+    #[test]
+    fn test_effort_alias_identical_to_level() {
+        let ctx = ctx_with_effort("xhigh");
+        let r1 = render(&ctx, &CshipConfig::default());
+        let r2 = render_level(&ctx, &CshipConfig::default());
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_effort_disabled_returns_none() {
+        let ctx = ctx_with_effort("high");
+        let cfg = CshipConfig {
+            effort: Some(EffortConfig {
+                disabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(render(&ctx, &cfg), None);
+    }
+
+    #[test]
+    fn test_effort_absent_returns_none() {
+        let ctx = Context::default(); // no effort field (model without effort support)
+        assert_eq!(render(&ctx, &CshipConfig::default()), None);
+    }
+
+    #[test]
+    fn test_effort_applies_symbol_and_style() {
+        let ctx = ctx_with_effort("max");
+        let cfg = CshipConfig {
+            effort: Some(EffortConfig {
+                symbol: Some("⚡ ".to_string()),
+                style: Some("bold magenta".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = render(&ctx, &cfg).unwrap();
+        assert!(result.contains("max"), "should contain level: {result:?}");
+        assert!(result.contains("⚡ "), "should contain symbol: {result:?}");
+        assert!(
+            result.contains('\x1b'),
+            "should contain ANSI codes: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_high() {
+        let ctx = ctx_with_effort("high");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("high", Some("yellow")),
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_max() {
+        let ctx = ctx_with_effort("max");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("max", Some("bold red")),
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_matches_case_insensitively() {
+        // A future Claude Code version sending "HIGH" should still map to high_style.
+        let ctx = ctx_with_effort("HIGH");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("HIGH", Some("yellow")),
+        );
+    }
+
+    #[test]
+    fn test_per_level_style_falls_back_to_base_style() {
+        // No max_style set — should use base style, not another level's style.
+        let ctx = ctx_with_effort("max");
+        let cfg = CshipConfig {
+            effort: Some(EffortConfig {
+                style: Some("bold green".to_string()),
+                high_style: Some("yellow".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("max", Some("bold green")),
+        );
+    }
+
+    #[test]
+    fn test_unknown_level_uses_base_style() {
+        let ctx = ctx_with_effort("ludicrous");
+        assert_eq!(
+            render(&ctx, &per_level_cfg()).unwrap(),
+            ansi::apply_style("ludicrous", Some("dim")),
+        );
+    }
+
+    #[test]
+    fn test_no_style_returns_plain_text() {
+        let ctx = ctx_with_effort("medium");
+        assert_eq!(render(&ctx, &CshipConfig::default()).unwrap(), "medium");
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod context_bar;
 pub mod context_window;
 pub mod cost;
+pub mod effort;
 pub mod model;
 pub mod peak_usage;
 pub mod session;
@@ -37,6 +38,8 @@ pub const ALL_NATIVE_MODULES: &[&str] = &[
     "cship.vim.mode",
     "cship.agent",
     "cship.agent.name",
+    "cship.effort",
+    "cship.effort.level",
     "cship.cwd",
     "cship.session_id",
     "cship.transcript_path",
@@ -106,6 +109,9 @@ pub fn render_module(
         // Agent module — agent name display
         "cship.agent" => agent::render(ctx, cfg),
         "cship.agent.name" => agent::render_name(ctx, cfg),
+        // Effort module — reasoning effort level display
+        "cship.effort" => effort::render(ctx, cfg),
+        "cship.effort.level" => effort::render_level(ctx, cfg),
         // Session identity modules
         "cship.cwd" => session::render_cwd(ctx, cfg),
         "cship.session_id" => session::render_session_id(ctx, cfg),

--- a/src/sample_context.json
+++ b/src/sample_context.json
@@ -40,5 +40,8 @@
   },
   "agent": {
     "name": "code"
+  },
+  "effort": {
+    "level": "high"
   }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -584,6 +584,81 @@ fn test_agent_absent_produces_no_output() {
         .stdout("");
 }
 
+// ── Effort module integration tests ──────────────────────────────────────
+
+#[test]
+fn test_effort_renders_level_string() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // sample_input_full.json: effort.level = "high"
+    cship()
+        .args(["--config", "tests/fixtures/effort_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("high"));
+}
+
+#[test]
+fn test_effort_level_subfield_renders_identically() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // effort_level_subfield.toml: lines = ["$cship.effort.level"] → same as $cship.effort
+    cship()
+        .args(["--config", "tests/fixtures/effort_level_subfield.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("high"));
+}
+
+#[test]
+fn test_effort_applies_symbol_and_style() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // effort_styled.toml: symbol = "⚡ ", style = "bold magenta" → ANSI codes present
+    cship()
+        .args(["--config", "tests/fixtures/effort_styled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["))
+        .stdout(predicate::str::contains("⚡ "));
+}
+
+#[test]
+fn test_effort_per_level_style_applies_to_high() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    // effort_per_level.toml: high_style = "bold yellow"; effort.level = "high" → ANSI codes
+    cship()
+        .args(["--config", "tests/fixtures/effort_per_level.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("high"))
+        .stdout(predicate::str::contains("\x1b["));
+}
+
+#[test]
+fn test_effort_disabled_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_full.json").unwrap();
+    cship()
+        .args(["--config", "tests/fixtures/effort_disabled.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn test_effort_absent_produces_no_output() {
+    let json = std::fs::read_to_string("tests/fixtures/sample_input_minimal.json").unwrap();
+    // sample_input_minimal.json has no effort field → empty render
+    cship()
+        .args(["--config", "tests/fixtures/effort_basic.toml"])
+        .write_stdin(json)
+        .assert()
+        .success()
+        .stdout("");
+}
+
 // ── Story 2.4: Session identity and workspace modules integration tests ───
 
 #[test]

--- a/tests/fixtures/effort_basic.toml
+++ b/tests/fixtures/effort_basic.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.effort"]

--- a/tests/fixtures/effort_disabled.toml
+++ b/tests/fixtures/effort_disabled.toml
@@ -1,0 +1,5 @@
+[cship]
+lines = ["$cship.effort"]
+
+[cship.effort]
+disabled = true

--- a/tests/fixtures/effort_level_subfield.toml
+++ b/tests/fixtures/effort_level_subfield.toml
@@ -1,0 +1,2 @@
+[cship]
+lines = ["$cship.effort.level"]

--- a/tests/fixtures/effort_per_level.toml
+++ b/tests/fixtures/effort_per_level.toml
@@ -1,0 +1,7 @@
+[cship]
+lines = ["$cship.effort"]
+
+[cship.effort]
+style       = "dim"
+high_style  = "bold yellow"
+max_style   = "bold red"

--- a/tests/fixtures/effort_styled.toml
+++ b/tests/fixtures/effort_styled.toml
@@ -1,0 +1,6 @@
+[cship]
+lines = ["$cship.effort"]
+
+[cship.effort]
+symbol = "⚡ "
+style  = "bold magenta"

--- a/tests/fixtures/sample_input_full.json
+++ b/tests/fixtures/sample_input_full.json
@@ -41,6 +41,9 @@
   "agent": {
     "name": "security-reviewer"
   },
+  "effort": {
+    "level": "high"
+  },
   "rate_limits": {
     "five_hour": {
       "used_percentage": 23.5,


### PR DESCRIPTION
Closes #187.

Adds a native `$cship.effort` module (alias `$cship.effort.level`) that shows the session's reasoning effort — `low`/`medium`/`high`/`xhigh`/`max` — from Claude Code's `effort.level`. It renders nothing when the active model doesn't support the effort parameter.

- **Per-level styling** — `low_style` … `max_style`, each falling back to the base `style` (mirrors `[cship.model]`'s per-family styles); plus the usual `symbol` / `style` / `format` / `disabled`. Level matching is case-insensitive.
- **`cship explain`** wired up — config-section column, disabled detection, and an effort-specific "model may not support effort" hint.
- Absent effort logs at `debug!`, not `warn!`, since absence is the normal state for non-effort models (cf. `context_bar`).
- Docs updated (configuration reference, FAQ, README table, CHANGELOG), and `$cship.effort` added to the Hero/Recommended showcase (README + `docs/showcase.md` + the repo `cship.toml`).

Verified locally: `fmt`, `clippy -D warnings`, 429 + 74 tests, and release build all green.
