### PR TITLE
fix(account): clamp fetch timeout, add explain hint, document module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `cship.account` module for displaying the currently authenticated Anthropic account (work vs personal) — sources organization and account info from the `/api/oauth/profile` endpoint, with opt-in label mapping so org names can be replaced with user-defined labels (e.g. `"Fulcrum Genomics" = "work"`). Supports format string placeholders: `{label}`, `{organization}`, `{display_name}`, `{email}`, `{tier}`, `{type}`. Cached for 24 hours (configurable via `ttl`). ([@nh13](https://github.com/nh13), [#153](https://github.com/stephenleo/cship/pull/153))
 
+### Fixed
+- `cship.account` HTTP fetch timeout lowered from 5s to 1500ms so it always completes inside the 2s `recv_timeout` window in `fetch_with_timeout`; previously a slow profile fetch was reported as timed out while the spawned thread (holding the OAuth token) kept running
+- `cship explain cship.account` now prints account-specific remediation (no credential / expired-or-unreachable / malformed credential) instead of the generic "module returned no value" fallback
+
+### Docs
+- Documented the `cship.account` module in the README module table, configuration guide, and FAQ (setup, label mapping, and `cship explain` diagnostics)
+
 ## [1.7.1] - 2026-05-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Everything in the [Claude Code status line documentation](https://code.claude.co
 | `$cship.usage_limits` | API usage limits (5hr / 7-day, plus per-model and extra-usage when available) |
 | `$cship.usage_limits.per_model` | 7-day per-model breakdown (opus / sonnet / cowork / oauth) |
 | `$cship.usage_limits.extra_usage` | Extra-credits section with `{active}` indicator |
+| `$cship.account` | Authenticated Anthropic account (work/personal); map org names via `labels` |
 | `$cship.peak_usage` | Peak-time indicator (US Pacific business hours) |
 | `$cship.agent` | Sub-agent name |
 | `$cship.session` | Session identity info |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -441,6 +441,55 @@ specific diagnostics.
 
 ---
 
+## `[cship.account]` — Authenticated Account
+
+Displays which Anthropic account the active Claude Code session is signed in to — handy for telling work and personal accounts apart at a glance. Profile data is fetched once from the OAuth `/api/oauth/profile` endpoint and cached for 24 hours (the profile rarely changes). The OAuth token is held only for the duration of the fetch — never written to disk, cache, stdout, or stderr.
+
+**Token:** `$cship.account`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `disabled` | `bool` | `false` | Hide this module |
+| `style` | `string` | — | ANSI style applied to the rendered value |
+| `symbol` | `string` | `""` | Prefix symbol prepended to the value |
+| `format` | `string` | `"{label}"` | Format string built from the placeholders below |
+| `ttl` | `integer` | `86400` | Cache TTL in seconds (default 24h). The cache is also invalidated automatically when you switch accounts (token fingerprint change). |
+| `labels` | `table` | — | Opt-in map from raw organization name → friendly label, e.g. `{ "Fulcrum Genomics" = "work", "Personal Workspace" = "personal" }` |
+
+**Placeholders** (available in `format`):
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `{label}` | Resolved label: a `labels` mapping for the organization if present, else the raw organization name, else the account display name |
+| `{organization}` | Raw organization name (e.g. `Fulcrum Genomics`) |
+| `{display_name}` | Account display name (e.g. `Nils`) |
+| `{email}` | Account email — treat as PII; opt in by referencing it in `format` |
+| `{tier}` | Organization rate-limit tier (e.g. `default_claude_max_5x`) |
+| `{type}` | Organization type (e.g. `claude_team`, `personal`) |
+
+**Prerequisites:** Requires an OAuth token in the OS credential store (the same credential used by `usage_limits`). On Linux/WSL2, install `libsecret-tools` and store your token with `secret-tool`. If the module renders nothing, run `cship explain cship.account` for a diagnosis (missing credential, expired token, or unreachable API).
+
+```toml
+[cship.account]
+symbol = " "
+style  = "bold fg:#7aa2f7"
+format = "{label}"
+
+# Map raw org names to short labels
+[cship.account.labels]
+"Fulcrum Genomics" = "work"
+"Personal Workspace" = "personal"
+```
+
+To show more detail, reference additional placeholders:
+
+```toml
+[cship.account]
+format = "{display_name} @ {organization}"
+```
+
+---
+
 ## `[cship.peak_usage]` — Peak-Time Indicator
 
 Shows when Anthropic's peak-time rate limiting is likely active, based on current time relative to US Pacific business hours. Returns nothing outside peak hours so the indicator disappears entirely.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -94,6 +94,30 @@ not enabled on your Enterprise account).
 
 ---
 
+## How do I set up the `cship.account` module, and why is it empty? {#account-setup}
+
+`cship.account` shows which Anthropic account you're signed in to (work vs
+personal). It reads your account profile from the OAuth `/api/oauth/profile`
+endpoint using the OAuth token in your OS credential store — the same
+credential `usage_limits` uses — so the [Linux/WSL2 setup above](#usage-limits-linux)
+applies here too (`libsecret-tools` + `secret-tool`). The profile is cached for
+24 hours and re-fetched automatically when you switch accounts.
+
+If the module renders nothing, run `cship explain cship.account`. It
+distinguishes the three causes: no credential found (authenticate in Claude
+Code), credential present but the profile fetch failed (token may have expired,
+or the API was unreachable — re-authenticate), or a malformed credential.
+
+To map raw organization names to short labels:
+
+```toml
+[cship.account.labels]
+"Fulcrum Genomics" = "work"
+"Personal Workspace" = "personal"
+```
+
+---
+
 ## How does the peak-time indicator handle time zones and DST?
 
 The `peak_usage` module checks whether the current time falls within the configured peak window in **US Pacific time**. It computes the UTC→Pacific offset internally — PDT (UTC−7) from the second Sunday of March through the first Sunday of November, PST (UTC−8) the rest of the year.

--- a/src/account.rs
+++ b/src/account.rs
@@ -71,7 +71,13 @@ pub fn parse_api_response(json: &str) -> Result<AccountProfile, String> {
 
 const API_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/profile";
 const OAUTH_BETA_HEADER: &str = "oauth-2025-04-20";
-const HTTP_TIMEOUT_SECS: u64 = 5;
+/// HTTP timeout in milliseconds. Must stay below the `FETCH_TIMEOUT_SECS` (2s)
+/// `recv_timeout` window in `modules::fetch_with_timeout`, otherwise the mpsc
+/// receiver gives up first and reports a timeout while this request is still
+/// in flight, leaking the spawned thread (and the live token) for the
+/// remainder of the HTTP timeout. See cship commit 06051f5 for the same fix
+/// applied to `usage_limits`.
+const HTTP_TIMEOUT_MS: u64 = 1500;
 
 /// Fetch the current account profile from the Anthropic OAuth API.
 /// Returns a structured `AccountProfile` or a descriptive `Err`.
@@ -80,7 +86,7 @@ pub fn fetch_account_profile(token: &str) -> Result<AccountProfile, String> {
 
     let agent = ureq::Agent::new_with_config(
         ureq::config::Config::builder()
-            .timeout_global(Some(Duration::from_secs(HTTP_TIMEOUT_SECS)))
+            .timeout_global(Some(Duration::from_millis(HTTP_TIMEOUT_MS)))
             .build(),
     );
     let mut response = agent

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -297,6 +297,28 @@ fn error_hint_for(
                 ),
             }
         }
+        "account" => {
+            // The account module renders nothing when the OAuth credential is
+            // missing/malformed, or when it is present but the profile fetch
+            // failed (and no fingerprint-matching stale cache is available).
+            // Probe credential state to give the right remediation.
+            // NOTE: like the `usage_limits` arm, this reads a credential —
+            // acceptable for interactive `cship explain`, never the hot path.
+            match crate::platform::get_oauth_token() {
+                Err(msg) if msg.contains("credentials not found") => (
+                    "account returned no data — no Claude Code credential found".into(),
+                    "Authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
+                ),
+                Ok(_) => (
+                    "account returned no data — credential present but profile fetch failed".into(),
+                    "Your Claude Code token may have expired, or the account profile API was unreachable. Re-authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
+                ),
+                Err(_) => (
+                    "account returned no data — credential appears malformed or tool unavailable".into(),
+                    "Re-authenticate by opening Claude Code and completing the login flow, then run `cship explain` again.".into(),
+                ),
+            }
+        }
         _ => (
             "module returned no value".into(),
             "Check cship configuration and ensure Claude Code is running.".into(),

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -2259,12 +2259,7 @@ mod tests {
             ..Default::default()
         };
         let fp = current_fingerprint();
-        crate::cache::write_usage_limits(
-            &transcript_path,
-            &data,
-            600,
-            fp.as_deref(),
-        );
+        crate::cache::write_usage_limits(&transcript_path, &data, 600, fp.as_deref());
 
         let ctx = Context {
             transcript_path: Some(transcript_path.to_string_lossy().into()),
@@ -2289,12 +2284,7 @@ mod tests {
             ..Default::default()
         };
         let fp = current_fingerprint();
-        crate::cache::write_usage_limits(
-            &transcript_path,
-            &data,
-            600,
-            fp.as_deref(),
-        );
+        crate::cache::write_usage_limits(&transcript_path, &data, 600, fp.as_deref());
 
         let ctx = Context {
             transcript_path: Some(transcript_path.to_string_lossy().into()),


### PR DESCRIPTION
Follow-up to #153. Addresses the two findings from the code review on that PR, plus the `account` module docs (which #153 did not include) and an unrelated CI breakage #153 left on `main`.

## Bug fixes
1. **HTTP timeout exceeded the fetch window.** `src/account.rs` used a 5s HTTP timeout, but `modules::fetch_with_timeout` only waits 2s on its `recv_timeout`. A slow profile fetch (2–5s) was reported as timed out at 2s while the spawned thread — holding the OAuth token — kept running. Lowered to **1500ms**, matching the fix applied to `usage_limits` in `06051f5`.
2. **`cship explain cship.account` gave a misleading hint.** `error_hint_for` had no `account` arm, so it fell through to the generic `"module returned no value"` / "Check cship configuration" message. Added a dedicated arm that probes credential state and returns account-specific remediation (no credential → authenticate; credential present but fetch failed → token expired/API unreachable, re-authenticate; malformed credential).

## CI fix
- `main` is currently **red**: #153 merged with two `cargo fmt` violations in `src/modules/usage_limits.rs` (lines 2259/2289). Applied `cargo fmt` to those two test lines so `cargo fmt --check` passes again.

## Docs
The `account` module shipped in #153 without documentation. Added it to:
- `README.md` — module table
- `docs/configuration.md` — full `[cship.account]` reference (fields, `{label}`/`{organization}`/`{display_name}`/`{email}`/`{tier}`/`{type}` placeholders, `labels` mapping, examples)
- `docs/faq.md` — setup, OAuth credential prerequisite, label mapping, and `cship explain` diagnostics
- `CHANGELOG.md` — Fixed + Docs entries

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (445 unit + 68 integration)
- `cargo build --release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)