### PR TITLE
fix(security):
  strip terminal control chars from untrusted session fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+- Strip terminal control characters (ESC, BEL, C0/C1, DEL) from untrusted Claude Code session JSON fields at ingest, closing an escape-sequence injection vector (CWE-150) where a malicious directory or model name could spoof the terminal title, reposition the cursor, or write the clipboard via OSC 52. Legitimate values are unaffected; only control bytes are removed ([#191](https://github.com/stephenleo/cship/pull/191))
+
 ### Changed
 - **Breaking:** `$cship.cost.total_duration_ms` and `$cship.cost.total_api_duration_ms` now render human-readable durations (`45s`, `1m30s`, `2h15m30s`, or `750ms` for sub-second values) instead of raw milliseconds. If your config has `format = "[$value ms]($style)"`, drop the literal ` ms` — `$value` is no longer in milliseconds. Threshold configs (`warn_threshold = 30000.0`) keep working unchanged because comparisons still operate on raw milliseconds (issue #162).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -160,3 +160,9 @@ Set `end_hour = 24` to mean "through end of day". Weekends always return nothing
 - If the cache seems stale, check that your OAuth token is valid (re-login to Claude Code if needed).
 
 You can see the current cache state by running `cship explain` — it shows the usage limits value being rendered and any warnings if the API call failed.
+
+## Why are some characters missing from my path or model name?
+
+cship strips terminal control characters (ESC, BEL, the C0/C1 ranges, and DEL — including tab, carriage return, and newline) from untrusted session JSON fields such as `cwd`, `transcript_path`, `model`, and `workspace` before rendering. This is a security measure: it prevents a malicious directory or model name from injecting raw escape sequences that could spoof your terminal title, move the cursor, or write to the clipboard via OSC 52 ([CWE-150](https://cwe.mitre.org/data/definitions/150.html)).
+
+Normal values are never affected — only control bytes are removed. If a path or name shows up with characters missing, it contained control bytes, which are stripped by design and cannot be disabled.

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -100,6 +100,22 @@ pub fn resolve_threshold_style<'a>(
     style
 }
 
+/// Remove terminal control characters from an untrusted string.
+///
+/// Fields in the Claude Code session JSON (directory names, model names, vim mode,
+/// agent name, etc.) may contain attacker-influenced bytes — e.g. a malicious repo
+/// can hold a directory whose name embeds raw ESC sequences. Emitting those verbatim
+/// to the terminal enables escape-sequence injection (CWE-150): window-title spoofing,
+/// cursor repositioning to overwrite on-screen text, or OSC 52 clipboard writes.
+///
+/// We drop every Unicode `Cc` (control) character, which covers ESC (0x1b), BEL (0x07),
+/// backspace, CR/LF/TAB, and the C1 range (U+0080–U+009F). Styling escapes are added
+/// later by [`apply_style`] from trusted config, so removing control bytes from the
+/// raw value loses nothing legitimate while neutralizing injected sequences.
+pub fn sanitize_control(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
 /// Strip ANSI escape sequences from a string, returning plain text.
 /// Used by `cship explain` to display module values in a readable table.
 pub fn strip_ansi(s: &str) -> String {
@@ -430,6 +446,32 @@ mod tests {
             "unexpected ANSI for #xyz: {result:?}"
         );
         assert_eq!(result, "text");
+    }
+
+    #[test]
+    fn test_sanitize_control_strips_escape_sequences() {
+        // A directory name carrying an OSC title-set + cursor-move payload.
+        let malicious = "repo\x1b]0;pwned\x07\x1b[1Aclean";
+        let out = sanitize_control(malicious);
+        assert!(!out.contains('\x1b'), "ESC must be stripped: {out:?}");
+        assert!(!out.contains('\x07'), "BEL must be stripped: {out:?}");
+        // Only the control bytes are removed; the now-inert printable remnants
+        // ("]0;pwned", "[1A") stay but can no longer drive the terminal.
+        assert_eq!(out, "repo]0;pwned[1Aclean");
+    }
+
+    #[test]
+    fn test_sanitize_control_strips_c1_and_whitespace_controls() {
+        // C1 control (U+0085 NEL) plus CR/LF/TAB are all dropped.
+        let out = sanitize_control("a\u{0085}b\r\nc\td");
+        assert_eq!(out, "abcd");
+    }
+
+    #[test]
+    fn test_sanitize_control_preserves_unicode_and_spaces() {
+        // Normal text, spaces, and non-control Unicode are untouched.
+        let s = "my project — café 🚀";
+        assert_eq!(sanitize_control(s), s);
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -107,6 +107,46 @@ pub struct Effort {
     pub level: Option<String>,
 }
 
+impl Context {
+    /// Strip terminal control characters from every untrusted string field.
+    ///
+    /// Called once at ingest so all downstream consumers (modules, passthrough,
+    /// `explain`, cache) receive terminal-safe values regardless of how they render.
+    /// Numeric/boolean fields cannot carry control bytes, so only string fields are
+    /// touched. See [`crate::ansi::sanitize_control`] for the threat model.
+    fn sanitize(&mut self) {
+        fn clean(opt: &mut Option<String>) {
+            if let Some(s) = opt {
+                *s = crate::ansi::sanitize_control(s);
+            }
+        }
+        clean(&mut self.cwd);
+        clean(&mut self.session_id);
+        clean(&mut self.transcript_path);
+        clean(&mut self.version);
+        if let Some(m) = &mut self.model {
+            clean(&mut m.id);
+            clean(&mut m.display_name);
+        }
+        if let Some(w) = &mut self.workspace {
+            clean(&mut w.current_dir);
+            clean(&mut w.project_dir);
+        }
+        if let Some(o) = &mut self.output_style {
+            clean(&mut o.name);
+        }
+        if let Some(v) = &mut self.vim {
+            clean(&mut v.mode);
+        }
+        if let Some(a) = &mut self.agent {
+            clean(&mut a.name);
+        }
+        if let Some(e) = &mut self.effort {
+            clean(&mut e.level);
+        }
+    }
+}
+
 /// Deserialize Claude Code session JSON from any reader.
 /// Uses exactly one `serde_json::from_str` call — no per-field parsing.
 ///
@@ -117,7 +157,8 @@ pub fn from_reader(mut reader: impl Read) -> anyhow::Result<Context> {
     if input.trim().is_empty() {
         anyhow::bail!("empty stdin: no Claude Code session JSON received");
     }
-    let ctx = serde_json::from_str(&input)?;
+    let mut ctx: Context = serde_json::from_str(&input)?;
+    ctx.sanitize();
     Ok(ctx)
 }
 
@@ -232,5 +273,77 @@ mod tests {
     fn test_whitespace_only_reader_returns_error() {
         let result = from_reader("   \n\t  ".as_bytes());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ingest_strips_control_chars_from_untrusted_fields() {
+        // Inject control bytes via unambiguous Rust escapes (ESC = \u{1b},
+        // BEL = \u{7}) into every untrusted field, then run the exact sanitize()
+        // pass from_reader() applies at ingest. Payloads mimic an OSC title-set,
+        // a CSI cursor-up, and an OSC 52 clipboard write smuggled in by a repo.
+        let mut ctx = Context {
+            cwd: Some("/repo\u{1b}]0;pwned\u{7}".to_string()),
+            workspace: Some(Workspace {
+                current_dir: Some("/a\u{1b}[1Ab".to_string()),
+                project_dir: Some("/p".to_string()),
+            }),
+            model: Some(Model {
+                id: Some("mX".to_string()),
+                display_name: Some("Opus\u{1b}]52;c;evil\u{7}".to_string()),
+            }),
+            vim: Some(Vim {
+                mode: Some("NORM\u{1b}AL".to_string()),
+            }),
+            agent: Some(Agent {
+                name: Some("age\u{7}nt".to_string()),
+            }),
+            effort: Some(Effort {
+                level: Some("high".to_string()),
+            }),
+            ..Default::default()
+        };
+        ctx.sanitize();
+        // Control bytes are gone; the inert printable remnants remain harmless.
+        assert_eq!(ctx.cwd.as_deref(), Some("/repo]0;pwned"));
+        let ws = ctx.workspace.unwrap();
+        assert_eq!(ws.current_dir.as_deref(), Some("/a[1Ab"));
+        assert_eq!(ws.project_dir.as_deref(), Some("/p"));
+        let model = ctx.model.unwrap();
+        assert_eq!(model.id.as_deref(), Some("mX"));
+        assert_eq!(model.display_name.as_deref(), Some("Opus]52;c;evil"));
+        assert_eq!(ctx.vim.unwrap().mode.as_deref(), Some("NORMAL"));
+        assert_eq!(ctx.agent.unwrap().name.as_deref(), Some("agent"));
+        assert_eq!(ctx.effort.unwrap().level.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn test_from_reader_decodes_then_strips_json_escaped_control() {
+        // End-to-end wiring: a JSON  escape decodes to a raw ESC byte,
+        // which from_reader()'s sanitize pass must then strip. The escape text is
+        // built with a doubled backslash so the JSON literally contains .
+        let json = format!(
+            r#"{{"cwd": "/repo{esc}]0;x", "model": {{"display_name": "Opus{esc}"}}}}"#,
+            esc = "\\u001b"
+        );
+        let ctx = from_reader(json.as_bytes()).unwrap();
+        assert_eq!(ctx.cwd.as_deref(), Some("/repo]0;x"));
+        assert_eq!(ctx.model.unwrap().display_name.as_deref(), Some("Opus"));
+    }
+
+    #[test]
+    fn test_ingest_preserves_clean_fields() {
+        // Sanitization must not alter legitimate values (regression guard).
+        let ctx: Context = serde_json::from_str(FULL_JSON).unwrap();
+        let mut sanitized = serde_json::from_str::<Context>(FULL_JSON).unwrap();
+        sanitized.sanitize();
+        assert_eq!(ctx.cwd, sanitized.cwd);
+        assert_eq!(
+            ctx.workspace.unwrap().current_dir,
+            sanitized.workspace.unwrap().current_dir
+        );
+        assert_eq!(
+            ctx.model.unwrap().display_name,
+            sanitized.model.unwrap().display_name
+        );
     }
 }


### PR DESCRIPTION
## Summary

Claude Code session JSON embeds attacker-influenced strings (directory names, model display names, vim mode, agent name, etc.). A malicious repo can name a directory with raw ESC sequences (delivered as JSON `\u001b` escapes, which serde decodes to real control bytes); cship rendered these verbatim to stdout, where the terminal interprets them — enabling window-title spoofing, cursor repositioning to overwrite on-screen text, or OSC 52 clipboard writes (CWE-150).

## Fix

- Add `ansi::sanitize_control`, which drops every Unicode `Cc` (control) character — ESC, BEL, BS, CR/LF/TAB, and the C1 range.
- Apply it once at ingest in `context.rs::from_reader`, after deserialization, to every untrusted string field. Raw JSON values never legitimately contain control bytes, and styling escapes are added *later* from trusted config, so this loses nothing while neutralizing injected sequences. Sanitizing at ingest covers every downstream consumer (modules, passthrough, `explain`, cache) uniformly.

## Testing

- New unit tests for `sanitize_control` (strips C0/C1/DEL, preserves Unicode/spaces) and ingest (`sanitize()` over all fields, a `from_reader` JSON-escape decode→strip check, and a regression guard that clean values are untouched).
- Full suite green: 484 lib + 74 integration tests, `cargo fmt --check`, `cargo clippy -D warnings`, release build.
- Manual end-to-end: a payload with `\u001b`-escaped sequences in `model.display_name` and `workspace.current_dir` renders as inert text (`]0;HACKEDX`, `[1A`) with zero stray ESC bytes, while legitimate `[s](bold green)` styling still emits its ANSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
