### PR TITLE
feat(usage_limits): add {reset_at} absolute reset-time placeholder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +153,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -215,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +261,7 @@ version = "1.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "filetime",
  "nu-ansi-term",
@@ -462,6 +495,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +649,17 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -963,6 +1031,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -1423,6 +1497,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,10 +1585,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror          = "2"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 nu-ansi-term       = "0.50"
+chrono             = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 rstest     = "0.26"

--- a/cship.toml
+++ b/cship.toml
@@ -36,8 +36,8 @@ critical_threshold = 50
 critical_style     = "bold fg:#f7768e"
 
 [cship.usage_limits]
-five_hour_format   = " 5h {pct}% ({reset})"
-seven_day_format   = " 7d {pct}% ({reset})"
+five_hour_format   = " 5h {pct}% {reset_at} ({reset})"
+seven_day_format   = " 7d {pct}% {reset_at} ({reset})"
 sonnet_format      = "🎼 {pct}% ({reset})"
 extra_usage_format = "{active} {pct}% (${used}/${limit})"
 separator          = " "

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,6 +406,7 @@ The sub-tokens let you place sections independently in your `lines` layout — e
 | `{pct}` | Percentage used as integer (e.g. `23`) |
 | `{remaining}` | Percentage remaining as integer (e.g. `77`) |
 | `{reset}` | Time-until-reset string (e.g. `4h12m`) |
+| `{reset_at}` | Absolute local reset time — clock-only if today (e.g. `7:42 PM`), weekday-prefixed otherwise (e.g. `Mon 9:00 AM`); `?` if unknown, `now` if already past |
 | `{pace}` | Signed headroom vs linear consumption — `+20%` (under pace), `-15%` (over pace), or `?` when unknown |
 
 **Placeholders specific to `extra_usage_format`** (the standard `{remaining}` percentage placeholder does **not** apply here — use `{remaining_credits}` instead):
@@ -422,8 +423,8 @@ The sub-tokens let you place sections independently in your `lines` layout — e
 ```toml
 [cship.usage_limits]
 ttl                = 300       # 5 minutes; increase if you run many concurrent sessions
-five_hour_format   = "5h {pct}% ({pace}, {reset})"
-seven_day_format   = "7d {pct}% ({pace}, {reset})"
+five_hour_format   = "5h {pct}% resets at {reset_at} ({reset})"
+seven_day_format   = "7d {pct}% resets at {reset_at} ({reset})"
 opus_format        = "opus {pct}%"
 sonnet_format      = "sonnet {pct}%"
 extra_usage_format = "{active} extra {pct}% (${used}/${limit})"

--- a/src/modules/usage_limits.rs
+++ b/src/modules/usage_limits.rs
@@ -362,6 +362,7 @@ fn data_from_stdin_rate_limits(ctx: &Context) -> Option<UsageLimitsData> {
 /// - `{pct}` — percentage used as integer (e.g. `"23"`)
 /// - `{remaining}` — percentage remaining as integer (e.g. `"77"`)
 /// - `{reset}` — time-until-reset string (e.g. `"4h12m"`)
+/// - `{reset_at}` — absolute local reset time (e.g. `"7:42 PM"` or `"Mon 9:00 AM"`)
 /// - `{pace}` — signed pace string (e.g. `"+20%"`, `"-15%"`, `"?"`)
 ///
 /// Per-model breakdowns (opus, sonnet, cowork, oauth_apps) are appended when
@@ -384,6 +385,7 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     let five_h_pct = format!("{:.0}", data.five_hour_pct);
     let five_h_remaining = format!("{:.0}", (100.0 - data.five_hour_pct).max(0.0));
     let five_h_reset = format_reset(five_h_epoch, now);
+    let five_h_reset_at = format_reset_at(five_h_epoch, now);
     let five_h_pace = format_pace(calculate_pace(
         data.five_hour_pct,
         five_h_epoch,
@@ -394,6 +396,7 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
     let seven_d_pct = format!("{:.0}", data.seven_day_pct);
     let seven_d_remaining = format!("{:.0}", (100.0 - data.seven_day_pct).max(0.0));
     let seven_d_reset = format_reset(seven_d_epoch, now);
+    let seven_d_reset_at = format_reset_at(seven_d_epoch, now);
     let seven_d_pace = format_pace(calculate_pace(
         data.seven_day_pct,
         seven_d_epoch,
@@ -414,11 +417,13 @@ fn format_output(data: &UsageLimitsData, cfg: &UsageLimitsConfig) -> String {
         .replace("{pct}", &five_h_pct)
         .replace("{remaining}", &five_h_remaining)
         .replace("{reset}", &five_h_reset)
+        .replace("{reset_at}", &five_h_reset_at)
         .replace("{pace}", &five_h_pace);
     let seven_d_part = seven_d_fmt
         .replace("{pct}", &seven_d_pct)
         .replace("{remaining}", &seven_d_remaining)
         .replace("{reset}", &seven_d_reset)
+        .replace("{reset_at}", &seven_d_reset_at)
         .replace("{pace}", &seven_d_pace);
 
     let mut parts: Vec<String> = vec![five_h_part, seven_d_part];
@@ -457,6 +462,7 @@ fn format_single_model(
         Some(_) => format_reset(model_epoch, now),
         None => "?".to_string(),
     };
+    let reset_at_str = format_reset_at(model_epoch, now);
     let pace_str = format_pace(calculate_pace(pct, model_epoch, SEVEN_DAY_SECS, now));
     let default_fmt;
     let fmt: &str = match fmt_override {
@@ -470,6 +476,7 @@ fn format_single_model(
         fmt.replace("{pct}", &pct_str)
             .replace("{remaining}", &remaining_str)
             .replace("{reset}", &reset_str)
+            .replace("{reset_at}", &reset_at_str)
             .replace("{pace}", &pace_str),
     )
 }
@@ -602,6 +609,28 @@ fn format_reset(epoch: Option<u64>, now: u64) -> String {
         Some(e) if now >= e => "now".to_string(),
         Some(e) => format_remaining_secs(e - now),
     }
+}
+
+/// Format a resolved epoch as an absolute local clock time.
+/// `None` → `"?"`, past → `"now"`, same local date as `now` → `"7:42 PM"`,
+/// a later local date → `"Mon 9:00 AM"`.
+fn format_reset_at(epoch: Option<u64>, now: u64) -> String {
+    match epoch {
+        None => "?".to_string(),
+        Some(e) if now >= e => "now".to_string(),
+        Some(e) => match (epoch_to_local(e), epoch_to_local(now)) {
+            (Some(reset), Some(today)) if reset.date_naive() == today.date_naive() => {
+                reset.format("%-I:%M %p").to_string()
+            }
+            (Some(reset), _) => reset.format("%a %-I:%M %p").to_string(),
+            _ => "?".to_string(),
+        },
+    }
+}
+
+/// Convert Unix epoch seconds to the local-timezone equivalent.
+fn epoch_to_local(secs: u64) -> Option<chrono::DateTime<chrono::Local>> {
+    chrono::DateTime::from_timestamp(secs as i64, 0).map(|utc| utc.with_timezone(&chrono::Local))
 }
 
 /// Format a number of remaining seconds as a compact human-readable string.
@@ -1071,6 +1100,70 @@ mod tests {
         );
     }
 
+    // ── format_reset_at() tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_format_reset_at_none_returns_question_mark() {
+        assert_eq!(format_reset_at(None, now_epoch()), "?");
+    }
+
+    #[test]
+    fn test_format_reset_at_past_returns_now() {
+        let now = now_epoch();
+        assert_eq!(format_reset_at(Some(0), now), "now");
+        assert_eq!(format_reset_at(Some(now.saturating_sub(1)), now), "now");
+    }
+
+    #[test]
+    fn test_format_reset_at_same_day_is_clock_only() {
+        use chrono::Timelike;
+        let now = now_epoch();
+        let local_now = epoch_to_local(now).unwrap();
+        // One minute before local midnight on `now`'s own date — guaranteed same
+        // calendar date as `now` regardless of system timezone, and always in the
+        // future unless the test runs in the literal last minute of the day.
+        let end_of_day = local_now
+            .date_naive()
+            .and_hms_opt(23, 59, 0)
+            .unwrap()
+            .and_local_timezone(chrono::Local)
+            .single()
+            .unwrap();
+        if local_now.hour() == 23 && local_now.minute() >= 59 {
+            return; // last minute of the day — skip to avoid the unrepresentable edge case
+        }
+        let result = format_reset_at(Some(end_of_day.timestamp() as u64), now);
+        assert!(
+            result.contains(':') && (result.contains("AM") || result.contains("PM")),
+            "expected clock-only format: {result}"
+        );
+        assert!(
+            !result
+                .split(' ')
+                .next()
+                .unwrap()
+                .chars()
+                .all(char::is_alphabetic),
+            "same-day format should not start with a weekday: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_reset_at_later_day_includes_weekday() {
+        let now = now_epoch();
+        // 30 days out: outside any plausible UTC offset, guaranteed different local date.
+        let result = format_reset_at(Some(now + 30 * 86400), now);
+        assert!(
+            result.contains(':') && (result.contains("AM") || result.contains("PM")),
+            "expected clock portion: {result}"
+        );
+        let weekday = result.split(' ').next().unwrap();
+        assert!(
+            weekday.chars().all(char::is_alphabetic) && weekday.len() == 3,
+            "expected 3-letter weekday prefix: {result}"
+        );
+    }
+
     #[test]
     fn test_resolve_epoch_from_iso_plus_offset() {
         // Anthropic API returns "+00:00" not "Z" — resolve_epoch must handle it
@@ -1134,6 +1227,45 @@ mod tests {
         assert!(
             result.contains("7d 45%/"),
             "expected custom 7d format: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_reset_at_placeholder() {
+        let data = sample_data();
+        let cfg = UsageLimitsConfig {
+            five_hour_format: Some("5h {pct}% at {reset_at}".into()),
+            seven_day_format: Some("7d {pct}% at {reset_at}".into()),
+            ..Default::default()
+        };
+        let result = format_output(&data, &cfg);
+        assert!(
+            !result.contains("{reset_at}"),
+            "placeholder should be substituted: {result:?}"
+        );
+        let weekday_count = result.matches(" at ").count();
+        assert_eq!(
+            weekday_count, 2,
+            "both sections should have a reset_at: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_format_single_model_reset_at_placeholder() {
+        let result = format_single_model(
+            "opus",
+            Some(50.0),
+            &Some("2099-01-01T00:00:00Z".into()),
+            Some("opus {pct}% at {reset_at}"),
+        )
+        .unwrap();
+        assert!(
+            !result.contains("{reset_at}"),
+            "placeholder should be substituted: {result:?}"
+        );
+        assert!(
+            result.contains(" at "),
+            "expected reset_at content: {result:?}"
         );
     }
 


### PR DESCRIPTION
Adds a `{reset_at}` placeholder to `$cship.usage_limits` (five-hour, seven-day, and per-model formats), giving an absolute local clock time alongside the existing relative `{reset}` countdown.

- **Format** — clock-only if the reset falls on today's local date (e.g. `7:42 PM`), weekday-prefixed otherwise (e.g. `Mon 9:00 AM`); `?` when the reset time is unknown, `now` when it's already past. Mirrors `{reset}`'s `None`/past handling.
- **New dependency** — `chrono` (`clock` feature only). Std has no portable local-timezone/DST API, and hand-rolling that conversion is a correctness trap; `chrono::Local` is the standard, minimal way to get it right.
- Wired into `format_output` (five-hour/seven-day sections) and `format_single_model` (per-model breakdown) alongside the existing `{pct}`/`{remaining}`/`{reset}`/`{pace}` substitutions.
- Docs updated: `docs/configuration.md` placeholder table + example block, and `cship.toml` (repo's own showcase config) updated to demonstrate `{reset_at}` in both formats.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (476 unit + 73 integration)
- `cargo build --release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)