### PR TITLE
feat(model): add family_style map for new model families

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,10 +86,11 @@ Displays the active Claude model name.
 | `haiku_style` | `string` | — | Style applied when the key contains `"haiku"` (case-insensitive) |
 | `sonnet_style` | `string` | — | Style applied when the key contains `"sonnet"` (case-insensitive) |
 | `opus_style` | `string` | — | Style applied when the key contains `"opus"` (case-insensitive) |
+| `family_style` | `table` | — | Map of substring → style, for families beyond haiku/sonnet/opus (e.g. `fable`) |
 
 **Variables:** `$value` (display name, e.g. `Claude Sonnet 4.5`), `$symbol`, `$style`
 
-Per-family styles are matched case-insensitively against `model.id` (e.g. `claude-opus-4-7`). If `id` is absent, `display_name` is used as the key instead — so a display name like `"My Sonnet Setup"` will trigger `sonnet_style`. When no family style matches or is set, `style` is used as the fallback.
+Per-family styles are matched case-insensitively against `model.id` (e.g. `claude-opus-4-7`). If `id` is absent, `display_name` is used as the key instead — so a display name like `"My Sonnet Setup"` will trigger `sonnet_style`. `family_style` works the same way but lets you add arbitrary family names without waiting on a cship release — new model families can be styled the moment they ship. `haiku_style`/`sonnet_style`/`opus_style` take priority over a matching `family_style` entry. When no family style matches or is set, `style` is used as the fallback.
 
 ```toml
 [cship.model]
@@ -100,6 +101,17 @@ style  = "bold fg:#7aa2f7"
 haiku_style  = "green"
 sonnet_style = "cyan"
 opus_style   = "magenta"
+
+# Any other family
+family_style.fable = "yellow"
+```
+
+For multiple entries, `family_style` can also be written as its own table instead of repeated dotted keys:
+
+```toml
+[cship.model.family_style]
+fable = "yellow"
+mythos = "red"
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Displays the active Claude model name.
 
 **Variables:** `$value` (display name, e.g. `Claude Sonnet 4.5`), `$symbol`, `$style`
 
-Per-family styles are matched case-insensitively against `model.id` (e.g. `claude-opus-4-7`). If `id` is absent, `display_name` is used as the key instead — so a display name like `"My Sonnet Setup"` will trigger `sonnet_style`. `family_style` works the same way but lets you add arbitrary family names without waiting on a cship release — new model families can be styled the moment they ship. `haiku_style`/`sonnet_style`/`opus_style` take priority over a matching `family_style` entry. When no family style matches or is set, `style` is used as the fallback.
+Per-family styles are matched case-insensitively against `model.id` (e.g. `claude-opus-4-7`). If `id` is absent, `display_name` is used as the key instead — so a display name like `"My Sonnet Setup"` will trigger `sonnet_style`. `family_style` works the same way but lets you add arbitrary family names without waiting on a cship release — new model families can be styled the moment they ship. `haiku_style`/`sonnet_style`/`opus_style` take priority over a matching `family_style` entry. When several `family_style` keys match the same model, the longest key wins. An empty key is ignored (it would otherwise match every model) with a one-time warning. When no family style matches or is set, `style` is used as the fallback.
 
 ```toml
 [cship.model]

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,10 @@ pub struct ModelConfig {
     pub haiku_style: Option<String>,
     pub sonnet_style: Option<String>,
     pub opus_style: Option<String>,
+    /// Generic per-family styles, keyed by substring to match against `model.id`
+    /// (fallback: `display_name`). Lets users style new model families (e.g. `fable`)
+    /// without a cship code change.
+    pub family_style: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Configuration for `[cship.cost]` — convenience alias for total cost display.

--- a/src/modules/model.rs
+++ b/src/modules/model.rs
@@ -1,5 +1,6 @@
 /// Resolve the effective style for the current model, preferring per-family styles over the
-/// base `style`. Family is detected from `model.id` (fallback: `display_name`) via substring.
+/// base `style`. Family is detected from `model.id` (fallback: `display_name`) via substring;
+/// `family_style` extends this to families beyond the hardcoded haiku/sonnet/opus.
 fn resolve_model_style<'a>(
     ctx: &'a crate::context::Context,
     model_cfg: Option<&'a crate::config::ModelConfig>,
@@ -20,7 +21,32 @@ fn resolve_model_style<'a>(
     } else {
         None
     };
-    family.or(cfg.style.as_deref())
+    // Fallback to user-configured family_style; longest matching key wins on overlap
+    let generic_family = family.or_else(|| {
+        cfg.family_style
+            .as_ref()
+            .and_then(|map| {
+                map.iter()
+                    .filter(|(f, _)| !f.is_empty() && key.contains(&f.to_lowercase()))
+                    .max_by_key(|(f, _)| f.len())
+                    .or_else(|| {
+                        if map.keys().any(|f| f.is_empty()) {
+                            // Empty key matches every model — ignore it, warn once
+                            static EMPTY_KEY_WARNED: std::sync::atomic::AtomicBool =
+                                std::sync::atomic::AtomicBool::new(false);
+                            if !EMPTY_KEY_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                                tracing::warn!(
+                                    "cship.model: family_style has an empty key — ignoring it \
+                                     (an empty key would match every model)"
+                                );
+                            }
+                        }
+                        None
+                    })
+            })
+            .map(|(_, style)| style.as_str())
+    });
+    generic_family.or(cfg.style.as_deref())
 }
 
 /// Render the `[cship.model]` module.
@@ -334,6 +360,111 @@ mod tests {
             ..Default::default()
         };
         let cfg = all_family_cfg("dim cyan", "bold blue", "bold magenta", "bold red");
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Opus", Some("bold magenta")),
+        );
+    }
+
+    #[test]
+    fn test_family_style_empty_key_ignored_falls_back_to_base_style() {
+        let ctx = ctx_with_id("claude-fable-5", "Fable");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                style: Some("bold red".to_string()),
+                family_style: Some(
+                    [("".to_string(), "bold yellow".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Fable", Some("bold red")),
+        );
+    }
+
+    #[test]
+    fn test_family_style_longest_matching_key_wins_on_overlap() {
+        let ctx = ctx_with_id("claude-opus-4-7", "Opus");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                family_style: Some(
+                    [
+                        ("us".to_string(), "bold red".to_string()),
+                        ("opus".to_string(), "bold magenta".to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Opus", Some("bold magenta")),
+        );
+    }
+
+    #[test]
+    fn test_family_style_map_styles_unknown_family() {
+        let ctx = ctx_with_id("claude-fable-5", "Fable");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                family_style: Some(
+                    [("fable".to_string(), "bold yellow".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Fable", Some("bold yellow")),
+        );
+    }
+
+    #[test]
+    fn test_family_style_map_key_matches_case_insensitively() {
+        let ctx = ctx_with_id("claude-fable-5", "Fable");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                family_style: Some(
+                    [("Fable".to_string(), "bold yellow".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&ctx, &cfg).unwrap(),
+            ansi::apply_style("Fable", Some("bold yellow")),
+        );
+    }
+
+    #[test]
+    fn test_legacy_family_style_takes_priority_over_family_style_map() {
+        let ctx = ctx_with_id("claude-opus-4-7", "Opus");
+        let cfg = CshipConfig {
+            model: Some(ModelConfig {
+                opus_style: Some("bold magenta".to_string()),
+                family_style: Some(
+                    [("opus".to_string(), "bold yellow".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
         assert_eq!(
             render(&ctx, &cfg).unwrap(),
             ansi::apply_style("Opus", Some("bold magenta")),


### PR DESCRIPTION
Adds a `family_style` config map to `[cship.model]`, so users can style new model families (e.g. Fable) the moment they ship, without waiting on a cship release. Complements the existing `haiku_style`/`sonnet_style`/`opus_style` fields, which still take priority for back-compat.

- **Case-insensitive substring matching** — mirrors the existing haiku/sonnet/opus behavior; matched against `model.id` (fallback: `display_name`).
- **Longest matching key wins on overlap** — if two `family_style` entries both substring-match the same model, the more specific (longer) key is used instead of relying on `HashMap`'s unspecified iteration order.
- **Empty keys ignored** — an empty key would otherwise match every model; logged once via `tracing::warn!`, mirroring the `FILL_WARNED` pattern in `renderer.rs`.
- Docs updated: `docs/configuration.md` — field reference, precedence order, and both TOML forms (dotted-key and table).

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (487 unit + 73 integration)
- `cargo build --release` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)